### PR TITLE
Add keybinding for selected tab operations

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,6 +36,15 @@
     },
     "all-tabs-url-as-list": {
       "description": "all tabs: * url"
+    },
+    "highlighted-tabs-link-as-list": {
+      "description": "selected tabs: * [title](url)"
+    },
+    "highlighted-tabs-title-as-list": {
+      "description": "selected tabs: * title"
+    },
+    "highlighted-tabs-url-as-list": {
+      "description": "selected tabs: * url"
     }
   },
   "options_ui": {


### PR DESCRIPTION
## Summary

Add keybinding for selected tab operations

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [x] Chrome stable (Windows)
- [x] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
