### PR TITLE
Migrate to Event Page from Background Page

### DIFF
--- a/src/background/badge.js
+++ b/src/background/badge.js
@@ -38,5 +38,8 @@ export default async function flashBadge(type) {
       return; // don't know what it is. quit.
   }
 
-  setTimeout(clearBadge, FLASH_BADGE_TIMEOUT);
+  chrome.alarms.create({ when: Date.now() + FLASH_BADGE_TIMEOUT });
+  chrome.alarms.onAlarm.addListener(() => {
+    clearBadge();
+  });
 }

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -2,36 +2,37 @@ import contextMenuHandler from './context-menus.js';
 import messageHandler from './message-handler.js';
 import flashBadge from './badge.js';
 
-// Always create context menus when running background page.
-// Since we don't use event page, this will presumably executed every time
-// the extension is loaded (once).
-//
-// NOTE: The examples shows that you need to use chrome.runtime.onInstalled,
-// but that's for non-persistent event page, not for persistent background page.
-// That example was used to prevent duplicate menu items.
-chrome.contextMenus.create({
-  id: 'current-page',
-  title: 'Copy [Page Title](URL)',
-  type: 'normal',
-  contexts: ['page'],
+chrome.runtime.onInstalled.addListener(() => {
+  // Always create context menus when running background page.
+  // Since we don't use event page, this will presumably executed every time
+  // the extension is loaded (once).
+  //
+  // NOTE: The examples shows that you need to use chrome.runtime.onInstalled,
+  // but that's for non-persistent event page, not for persistent background page.
+  // That example was used to prevent duplicate menu items.
+  chrome.contextMenus.create({
+    id: 'current-page',
+    title: 'Copy [Page Title](URL)',
+    type: 'normal',
+    contexts: ['page'],
+  });
+
+  chrome.contextMenus.create({
+    id: 'link',
+    title: 'Copy [Link Content](URL)',
+    type: 'normal',
+    contexts: ['link'],
+  });
+
+  chrome.contextMenus.create({
+    id: 'image',
+    title: 'Copy ![](Image URL)', // TODO: how to fetch alt text?
+    type: 'normal',
+    contexts: ['image'],
+  });
 });
 
-chrome.contextMenus.create({
-  id: 'link',
-  title: 'Copy [Link Content](URL)',
-  type: 'normal',
-  contexts: ['link'],
-});
-
-chrome.contextMenus.create({
-  id: 'image',
-  title: 'Copy ![](Image URL)', // TODO: how to fetch alt text?
-  type: 'normal',
-  contexts: ['image'],
-});
-
-// NOTE: All listeners must be registered at top level scope.
-
+// listen to context menus
 chrome.contextMenus.onClicked.addListener(contextMenuHandler);
 
 // listen to keyboard shortcuts

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,6 +5,7 @@
   "manifest_version": 2,
   "description": "Copy Link or Image as Markdown code",
   "permissions": [
+    "alarms",
     "contextMenus",
     "clipboardWrite",
     "tabs"
@@ -22,7 +23,7 @@
   },
   "background": {
     "page": "./background.html",
-    "persistent": true
+    "persistent": false
   },
   "commands": {
     "current-tab-link": {


### PR DESCRIPTION
## Summary

Migrate to Event Page architecture to follow the latest best practices of Chrome Extensions.

As a part of QA, I'm going to run this version on my computers for a few days.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
