### PR TITLE
Workaround: Menus disappears on Firefox when restarted

### DIFF
--- a/firefox-mv2/background.html
+++ b/firefox-mv2/background.html
@@ -3,5 +3,6 @@
   <head><meta charset="utf-8"></head>
   <body>
     <script type="module" src="./dist/background.js"></script>
+    <script type="module" src="./create-menus.js"></script>
   </body>
 </html>

--- a/firefox-mv2/create-menus.js
+++ b/firefox-mv2/create-menus.js
@@ -1,0 +1,37 @@
+// This file is a workaround for Firefox event page.
+// It is executed every time background.js is loaded.
+//
+// In Chrome/Chromium, browsers, the suggested way to create a context menu is calling
+// `chrome.contextMenu.create()` in `chrome.runtime.onInstalled()`. This function will be called
+// when browser is restarted.
+//
+// In Firefox, the behavior is slightly different, such that onInstalled() is called ONLY at the
+// first time the add-on is installed. It is NOT called when the browser is restarted.
+//
+// As a workaround, in Firefox, call contextMenus.create() everytime background.js is loaded.
+//
+// For more details, see the following issues on Firefox's bug tracker:
+//
+// * https://bugzilla.mozilla.org/show_bug.cgi?id=1567467
+// * https://bugzilla.mozilla.org/show_bug.cgi?id=1558336
+
+chrome.contextMenus.create({
+  id: 'current-page',
+  title: 'Copy [Page Title](URL)',
+  type: 'normal',
+  contexts: ['page'],
+});
+
+chrome.contextMenus.create({
+  id: 'link',
+  title: 'Copy [Link Content](URL)',
+  type: 'normal',
+  contexts: ['link'],
+});
+
+chrome.contextMenus.create({
+  id: 'image',
+  title: 'Copy ![](Image URL)', // TODO: how to fetch alt text?
+  type: 'normal',
+  contexts: ['image'],
+});

--- a/firefox-mv2/manifest.json
+++ b/firefox-mv2/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Copy as Markdown",
-  "version": "2.6.2rc1",
+  "version": "2.6.0",
   "manifest_version": 2,
   "description": "Copy Link or Image as Markdown code",
   "permissions": [

--- a/firefox-mv2/manifest.json
+++ b/firefox-mv2/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Copy as Markdown",
-  "version": "2.6.0",
+  "version": "2.6.2rc1",
   "manifest_version": 2,
   "description": "Copy Link or Image as Markdown code",
   "permissions": [


### PR DESCRIPTION
Solves #107 

`chrome.runtime.onInstalled` is not called when Firefox restarted. This behavior is inconsistent with Chrome.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1567467

Followup explores:  (not a release blocker)

- Confirm behavior on Firefox MV3
- Refactor code so that codes of menus creation are not copy-pasted.
- Consider introducing custom menu lifecycle manager like uBlock?

## Summary

<!-- briefly describe changes here -->

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
