### PR TITLE
Attempt to solve the issue of context menu with MV3

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ because they get uninstalled after Firefox quits.
 Firefox checks signature when installing XPI. To do so, 
 
 1. Grab [API keys](https://addons.mozilla.org/en-US/developers/addon/api/key/) from Firefox Add-On
-2. Bump version in `manifest.json` and use something like `2.3.4b1` or `2.3.4rc1`
+2. Bump version in `manifest.json`. Note that AMO only accepts version number in `X.Y.Z` format where all 3 segments are numbers without zero prefix.
 3. Run:
     ```shell
     web-ext sign --channel=unlisted --api-key=... --api-secret=...
@@ -101,7 +101,7 @@ It'll create an XPI that is signed with your Firefox Add-Ons account. The file w
 uploaded to Add-On Developer Hub as unlisted.
 
 Note that Firefox Add-On keeps track of all the versions that has ever been uploaded, including
-'self-distributed' (`channel=unlisted`). That's why using a `b1` or `rc1` suffix is preferred.
+'self-distributed' (`channel=unlisted`). 
 
 See https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/
 

--- a/firefox/background.html
+++ b/firefox/background.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head><meta charset="utf-8"></head>
-  <body>
-    <script type="module" src="./dist/background.js"></script>
-  </body>
-</html>

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -26,7 +26,8 @@
     "128": "./dist/images/icon-128.png"
   },
   "background": {
-    "page": "background.html"
+    "scripts": ["./dist/background.js"],
+    "type": "module"
   },
   "commands": {
     "current-tab-link": {
@@ -57,7 +58,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "jid1-tfBgelm3d4bLkQ@jetpack",
-      "strict_min_version": "60.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug-chrome": "npx nodemon --exec 'sh compile.sh chrome' & npx web-ext run -s chrome/ -t chromium --args chrome://extensions https://example.com",
     "debug-edge": "npx nodemon --exec 'sh compile.sh chrome' & npx web-ext run -s chrome/ -t chromium --chromium-binary '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge' --args chrome://extensions https://example.com",
     "debug-firefox-mv2": "npx nodemon --exec 'sh compile.sh firefox-mv2' & npx web-ext run -s firefox-mv2/ --url about:debugging#/runtime/this-firefox https://example.com",
-    "debug-firefox": "npx nodemon --exec 'sh compile.sh firefox' & npx web-ext run -s firefox/ --firefox-preview --url about:debugging#/runtime/this-firefox https://example.com",
+    "debug-firefox": "npx nodemon --exec 'sh compile.sh firefox' & npx web-ext run -s firefox/ --url about:debugging#/runtime/this-firefox https://example.com",
     "eslint": "eslint .",
     "clean": "rm -rf ./build/* firefox/dist/* firefox-mv2/dist/* chrome/dist/*",
     "convert-images": "./utils/convert-images.sh"


### PR DESCRIPTION
Firefox 112 now supports ESM background script in MV3. This means that

1. The problem with contextMenu.create() not being called in chrome.runtime.onInstalled is gone.
2. No more background.html hack

See:

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background
https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/