### PR TITLE
Use dash for unordered lists

### DIFF
--- a/src/lib/markdown.js
+++ b/src/lib/markdown.js
@@ -133,7 +133,7 @@ export default class Markdown {
   }
 
   static list(theList) {
-    return theList.map((item) => `* ${item}`).join('\n');
+    return theList.map((item) => `- ${item}`).join('\n');
   }
 
   links(theLinks) {


### PR DESCRIPTION
## Summary

Change the unordered list bullet from asterisk (`*`) to dash (`-`).

Why?

1. Prettier formats Markdown with dashes, see https://github.com/prettier/prettier/issues/4251
2. [Logseq](https://github.com/logseq/logseq) also uses dashes for unordered lists. Pasting multiple links with asterisks is not recognized as a list by Logseq.

I'm aware that the specs allow both of them though:

- [Lists | Daring Fireball: Markdown Syntax Documentation](https://daringfireball.net/projects/markdown/syntax#list)
- [List items | CommonMark Spec](https://spec.commonmark.org/0.31.2/#list-items)

## Tests

I use [Brave Browser](https://github.com/brave/brave-browser), which is Chromium-compatible and can use Chrome extensions.

So I only tested on this one.

- [x] Brave Browser stable (macOS)
- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [x] Brave Browser beta (macOS)
- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
