### PR TITLE
Hack: Periodically re-create context menus in Firefox

### DIFF
--- a/firefox/hacks.js
+++ b/firefox/hacks.js
@@ -1,0 +1,1 @@
+globalThis["PERIDOCIALLY_REFRESH_MENU"] = true;

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Copy as Markdown",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "manifest_version": 3,
   "description": "Copy Link or Image as Markdown code",
   "permissions": [
@@ -26,7 +26,10 @@
     "128": "./dist/images/icon-128.png"
   },
   "background": {
-    "scripts": ["./dist/background.js"],
+    "scripts": [
+      "hacks.js",
+      "./dist/background.js"
+    ],
     "type": "module"
   },
   "commands": {


### PR DESCRIPTION
## Summary
In Firefox, when context menus were created in MV3, they may disappear unintentionally, even after restart. This is due to a bug in Firefox [1].

This patch introduces a hack which removes and re-creates all the menus every 30 seconds.

[1]: https://discourse.mozilla.org/t/strange-mv3-behaviour-browser-runtime-oninstalled-event-and-menus-create/111208/7

Related: #109 

<!-- briefly describe changes here -->

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
