### PR TITLE
Allow choosing the style of unorderd list

### DIFF
--- a/firefox/hacks.js
+++ b/firefox/hacks.js
@@ -1,1 +1,2 @@
-globalThis["PERIDOCIALLY_REFRESH_MENU"] = true;
+/* eslint-disable no-undef */
+globalThis.PERIDOCIALLY_REFRESH_MENU = true;

--- a/src/background.js
+++ b/src/background.js
@@ -62,6 +62,29 @@ async function flashBadge(type) {
   chrome.alarms.create('clear', { when: Date.now() + FLASH_BADGE_TIMEOUT });
 }
 
+function createMenus() {
+  chrome.contextMenus.create({
+    id: 'current-page',
+    title: 'Copy [Page Title](URL)',
+    type: 'normal',
+    contexts: ['page'],
+  });
+
+  chrome.contextMenus.create({
+    id: 'link',
+    title: 'Copy [Link Content](URL)',
+    type: 'normal',
+    contexts: ['link'],
+  });
+
+  chrome.contextMenus.create({
+    id: 'image',
+    title: 'Copy ![](Image URL)', // TODO: how to fetch alt text?
+    type: 'normal',
+    contexts: ['image'],
+  });
+}
+
 chrome.alarms.onAlarm.addListener((alarm) => {
   const entrypoint = chrome.action /* MV3 */ || chrome.browserAction; /* Firefox MV2 */
 
@@ -176,36 +199,14 @@ async function mustGetCurrentTab() {
   return Promise.resolve(tabs[0]);
 }
 
-function createMenus() {
-  chrome.contextMenus.create({
-    id: 'current-page',
-    title: 'Copy [Page Title](URL)',
-    type: 'normal',
-    contexts: ['page'],
-  });
-
-  chrome.contextMenus.create({
-    id: 'link',
-    title: 'Copy [Link Content](URL)',
-    type: 'normal',
-    contexts: ['link'],
-  });
-
-  chrome.contextMenus.create({
-    id: 'image',
-    title: 'Copy ![](Image URL)', // TODO: how to fetch alt text?
-    type: 'normal',
-    contexts: ['image'],
-  });
-}
-
 chrome.runtime.onInstalled.addListener(createMenus);
 
-if (globalThis["PERIDOCIALLY_REFRESH_MENU"] === true) {
+// eslint-disable-next-line no-undef
+if (globalThis.PERIDOCIALLY_REFRESH_MENU === true) {
   // Hack for Firefox, in which Context Menu disappears after some time.
   // See https://discourse.mozilla.org/t/strange-mv3-behaviour-browser-runtime-oninstalled-event-and-menus-create/111208/7
-  console.info("Hack PERIDOCIALLY_REFRESH_MENU is enabled");
-  chrome.alarms.create("refreshMenu", { periodInMinutes: 0.5});
+  console.info('Hack PERIDOCIALLY_REFRESH_MENU is enabled');
+  chrome.alarms.create('refreshMenu', { periodInMinutes: 0.5 });
 }
 
 // NOTE: All listeners must be registered at top level scope.

--- a/src/lib/markdown.js
+++ b/src/lib/markdown.js
@@ -4,8 +4,9 @@ export default class Markdown {
     return '(No Title)';
   }
 
-  constructor({ alwaysEscapeLinkBracket }) {
-    this._alwaysEscapeLinkBracket = alwaysEscapeLinkBracket || false;
+  constructor({ alwaysEscapeLinkBracket = false, unorderedListChar = '-' } = {}) {
+    this._alwaysEscapeLinkBracket = alwaysEscapeLinkBracket;
+    this._unorderedListChar = unorderedListChar;
   }
 
   /**
@@ -132,12 +133,12 @@ export default class Markdown {
     return `[![${description}](${url})](${linkURL})`;
   }
 
-  static list(theList) {
-    return theList.map((item) => `- ${item}`).join('\n');
+  list(theList) {
+    return theList.map((item) => `${this._unorderedListChar} ${item}`).join('\n');
   }
 
   links(theLinks) {
-    return this.constructor.list(theLinks.map((link) => this.linkTo(link.title, link.url)));
+    return this.list(theLinks.map((link) => this.linkTo(link.title, link.url)));
   }
 
   get alwaysEscapeLinkBracket() {
@@ -146,5 +147,13 @@ export default class Markdown {
 
   set alwaysEscapeLinkBracket(value) {
     this._alwaysEscapeLinkBracket = value;
+  }
+
+  get unorderedListChar() {
+    return this._unorderedListChar;
+  }
+
+  set unorderedListChar(value) {
+    this._unorderedListChar = value;
   }
 }

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -1,4 +1,5 @@
 const SKLinkTextAlwaysEscapeBrackets = 'linkTextAlwaysEscapeBrackets';
+const SKStyleOfUnorderedList = 'styleOfUnorderedList ';
 
 /**
  * Singleton Settings object in the chrome.storage.sync storage
@@ -17,16 +18,38 @@ export default {
 
   /**
    * @param {boolean} value
-   * @return {Promise<boolean>}
+   * @return {Promise<void>}
    * */
   async setLinkTextAlwaysEscapeBrackets(value) {
-    return chrome.storage.sync.set({
+    await chrome.storage.sync.set({
       [SKLinkTextAlwaysEscapeBrackets]: value,
+    });
+    this.publishUpdated();
+  },
+
+  async getStyleOfUnorderedList() {
+    return new Promise((resolve) => {
+      chrome.storage.sync.get(SKStyleOfUnorderedList, (data) => {
+        resolve(data[SKStyleOfUnorderedList] || 'dash');
+      });
     });
   },
 
+  async setStyleOfUnrderedList(value) {
+    await chrome.storage.sync.set({
+      [SKStyleOfUnorderedList]: value,
+    });
+    this.publishUpdated();
+  },
+
   async reset() {
-    return chrome.storage.sync.clear();
+    await chrome.storage.sync.clear();
+    this.publishUpdated();
+  },
+
+  publishUpdated() {
+    // NOTE: Do not await, or it will block
+    chrome.runtime.sendMessage({ topic: 'settings-updated' });
   },
 
   async getAll() {

--- a/src/ui/options.html
+++ b/src/ui/options.html
@@ -12,8 +12,18 @@
   </style>
 </head>
 <body>
+  <h2>Style</h2>
+  <form id='form-style-of-unordered-list'>
+    <fieldset>
+    <legend>Unordred List</legend>
+    <label><input type="radio" name="character" value="dash" /> Dashes (<mark>-</mark>)</label>
+    <label><input type="radio" name="character" value="asterisk" /> Asterisks (<mark>*</mark>)</label>
+    <label><input type="radio" name="character" value="plus" /> Plus Signs (<mark>+</mark>)</label>
+    </fieldset>
+  </form>
 
-  <form id="form">
+  <form id="form">    
+    <h2>Advanced</h2>
     <label>
       <input type="checkbox" name="link-text-always-escape-brackets" />
       Always escape brackets in Markdown link text (<code>[]</code> becomes <code>\[\]</code>)

--- a/src/ui/options.js
+++ b/src/ui/options.js
@@ -6,6 +6,10 @@ function loadSettings() {
   Settings.getLinkTextAlwaysEscapeBrackets().then((value) => {
     document.querySelector(SelLinkTextAlwaysEscapeBrackets).checked = value;
   });
+
+  Settings.getStyleOfUnorderedList().then((value) => {
+    document.forms['form-style-of-unordered-list'].elements.character.value = value;
+  });
 }
 
 document.addEventListener('DOMContentLoaded', loadSettings);
@@ -19,6 +23,15 @@ document.querySelector(SelLinkTextAlwaysEscapeBrackets)
         console.error('failed to save settings:', error);
       });
   });
+
+document.forms['form-style-of-unordered-list'].addEventListener('change', (event) => {
+  Settings.setStyleOfUnrderedList(event.target.value)
+    .then(() => {
+      console.info('settings saved');
+    }, (error) => {
+      console.error('failed to save settings:', error);
+    });
+});
 
 document.querySelector('#reset').addEventListener('click', () => {
   const resettings = Settings.reset()

--- a/test/markdown.test.js
+++ b/test/markdown.test.js
@@ -7,6 +7,18 @@ describe('Markdown', () => {
     assert.equal(markdown.alwaysEscapeLinkBracket, false);
   });
 
+  describe('list()', () => {
+    it('defaults to dash', () => {
+      const markdown = new Markdown();
+      assert.equal(markdown.list(['a', 'b', 'c']), '- a\n- b\n- c');
+    });
+
+    it('can set a character', () => {
+      const markdown = new Markdown({ unorderedListChar: '*' });
+      assert.equal(markdown.list(['a', 'b', 'c']), '* a\n* b\n* c');
+    });
+  });
+
   describe('bracketsArePaired()', () => {
     it('cases', () => {
       assert.equal(Markdown.bracketsAreBalanced('[]'), true);


### PR DESCRIPTION
## Summary

- New option: unordered list style (`-`, `*` or `+`). 
- Changed default style of unordered list to `-` as this is more common today. (See #126) 

Closes #98 

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
