### PR TITLE
Copy Links of Tabs as Task List

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -34,22 +34,28 @@
       "description": "current tab: [title](url)"
     },
     "all-tabs-link-as-list": {
-      "description": "all tabs: * [title](url)"
+      "description": "all tabs: - [title](url)"
+    },
+    "all-tabs-link-as-task-list": {
+      "description": "all tabs: - [ ] [title](url)"
     },
     "all-tabs-title-as-list": {
-      "description": "all tabs: * title"
+      "description": "all tabs: - title"
     },
     "all-tabs-url-as-list": {
-      "description": "all tabs: * url"
+      "description": "all tabs: - url"
     },
     "highlighted-tabs-link-as-list": {
-      "description": "selected tabs: * [title](url)"
+      "description": "selected tabs: - [title](url)"
+    },
+    "highlighted-tabs-link-as-task-list": {
+      "description": "selected tabs: - [ ] [title](url)"
     },
     "highlighted-tabs-title-as-list": {
-      "description": "selected tabs: * title"
+      "description": "selected tabs: - title"
     },
     "highlighted-tabs-url-as-list": {
-      "description": "selected tabs: * url"
+      "description": "selected tabs: - url"
     }
   },
   "options_ui": {

--- a/firefox-mv2/manifest.json
+++ b/firefox-mv2/manifest.json
@@ -34,22 +34,28 @@
       "description": "current tab: [title](url)"
     },
     "all-tabs-link-as-list": {
-      "description": "all tabs: * [title](url)"
+      "description": "all tabs: - [title](url)"
+    },
+    "all-tabs-link-as-task-list": {
+      "description": "all tabs: - [ ] [title](url)"
     },
     "all-tabs-title-as-list": {
-      "description": "all tabs: * title"
+      "description": "all tabs: - title"
     },
     "all-tabs-url-as-list": {
-      "description": "all tabs: * url"
+      "description": "all tabs: - url"
     },
     "highlighted-tabs-link-as-list": {
-      "description": "selected tabs: * [title](url)"
+      "description": "selected tabs: - [title](url)"
+    },
+    "highlighted-tabs-link-as-task-list": {
+      "description": "selected tabs: - [ ] [title](url)"
     },
     "highlighted-tabs-title-as-list": {
-      "description": "selected tabs: * title"
+      "description": "selected tabs: - title"
     },
     "highlighted-tabs-url-as-list": {
-      "description": "selected tabs: * url"
+      "description": "selected tabs: - url"
     }
   },
   "options_ui": {

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -37,22 +37,28 @@
       "description": "current tab: [title](url)"
     },
     "all-tabs-link-as-list": {
-      "description": "all tabs: * [title](url)"
+      "description": "all tabs: - [title](url)"
+    },
+    "all-tabs-link-as-task-list": {
+      "description": "all tabs: - [ ] [title](url)"
     },
     "all-tabs-title-as-list": {
-      "description": "all tabs: * title"
+      "description": "all tabs: - title"
     },
     "all-tabs-url-as-list": {
-      "description": "all tabs: * url"
+      "description": "all tabs: - url"
     },
     "highlighted-tabs-link-as-list": {
-      "description": "selected tabs: * [title](url)"
+      "description": "selected tabs: - [title](url)"
+    },
+    "highlighted-tabs-link-as-task-list": {
+      "description": "selected tabs: - [ ] [title](url)"
     },
     "highlighted-tabs-title-as-list": {
-      "description": "selected tabs: * title"
+      "description": "selected tabs: - title"
     },
     "highlighted-tabs-url-as-list": {
-      "description": "selected tabs: * url"
+      "description": "selected tabs: - url"
     }
   },
   "options_ui": {

--- a/src/background.js
+++ b/src/background.js
@@ -160,6 +160,12 @@ async function handleExport(action) {
       return markdownInstance.links(tabs, {});
     }
 
+    case 'all-tabs-link-as-task-list': {
+      const tabs = await asyncTabsQuery({ currentWindow: true });
+      const links = tabs.map((tab) => markdownInstance.linkTo(tab.title, tab.url));
+      return Markdown.taskList(links);
+    }
+
     case 'all-tabs-title-as-list': {
       const tabs = await asyncTabsQuery({ currentWindow: true });
       return markdownInstance.list(tabs.map((tab) => tab.title));
@@ -173,6 +179,12 @@ async function handleExport(action) {
     case 'highlighted-tabs-link-as-list': {
       const tabs = await asyncTabsQuery({ currentWindow: true, highlighted: true });
       return markdownInstance.links(tabs, {});
+    }
+
+    case 'highlighted-tabs-link-as-task-list': {
+      const tabs = await asyncTabsQuery({ currentWindow: true, highlighted: true });
+      const links = tabs.map((tab) => markdownInstance.linkTo(tab.title, tab.url));
+      return Markdown.taskList(links);
     }
 
     case 'highlighted-tabs-title-as-list': {

--- a/src/lib/markdown.js
+++ b/src/lib/markdown.js
@@ -137,6 +137,10 @@ export default class Markdown {
     return theList.map((item) => `${this._unorderedListChar} ${item}`).join('\n');
   }
 
+  static taskList(theList) {
+    return theList.map((item) => `- [ ] ${item}`).join('\n');
+  }
+
   links(theLinks) {
     return this.list(theLinks.map((link) => this.linkTo(link.title, link.url)));
   }

--- a/src/ui/popup.html
+++ b/src/ui/popup.html
@@ -17,6 +17,11 @@
     </div>
     <div class="panel-list-item">
       <div class="icon"></div>
+      <div class="text" data-action="all-tabs-link-as-task-list">All tabs link (task list)</div>
+      <div class="text-shortcut"></div>
+    </div>
+    <div class="panel-list-item">
+      <div class="icon"></div>
       <div class="text" data-action="all-tabs-title-as-list">All tabs title</div>
       <div class="text-shortcut"></div>
     </div>
@@ -29,6 +34,11 @@
     <div class="panel-list-item">
       <div class="icon"></div>
       <div class="text" data-action="highlighted-tabs-link-as-list">Selected tabs link (<span id="display-count-highlighted-tabs">0</span>)</div>
+      <div class="text-shortcut"></div>
+    </div>
+    <div class="panel-list-item">
+      <div class="icon"></div>
+      <div class="text" data-action="highlighted-tabs-link-as-task-list">Selected tabs link (task list)</div>
       <div class="text-shortcut"></div>
     </div>
     <div class="panel-list-item">

--- a/test/markdown.test.js
+++ b/test/markdown.test.js
@@ -19,6 +19,12 @@ describe('Markdown', () => {
     });
   });
 
+  describe('taskList()', () => {
+    it('works', () => {
+      assert.equal(Markdown.taskList(['a', 'b', 'c']), '- [ ] a\n- [ ] b\n- [ ] c');
+    });
+  });
+
   describe('bracketsArePaired()', () => {
     it('cases', () => {
       assert.equal(Markdown.bracketsAreBalanced('[]'), true);


### PR DESCRIPTION
## Summary

- A new menu item to copy links of tabs as task list (GitHub Flavored Markdown) in the popup window.
- Keyboard Shortcut for task list copying.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
