### PR TITLE
Feature: Copy page selection as Markdown

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
         "sourceType": "module",
         "ecmaVersion": 8
     },
-    "ignorePatterns": ["firefox/dist", "chrome/dist", "firefox-mv2/dist"],
+    "ignorePatterns": ["firefox/dist", "chrome/dist", "firefox-mv2/dist", "**/vendor/"],
     "rules": {
         "no-console": 0,
         "import/extensions": [

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -30,6 +30,9 @@
     "type": "module"
   },
   "commands": {
+    "selection-as-markdown": {
+      "description": "Copy Selection as Markdown"
+    },
     "current-tab-link": {
       "description": "current tab: [title](url)"
     },

--- a/firefox-mv2/manifest.json
+++ b/firefox-mv2/manifest.json
@@ -30,6 +30,9 @@
     "persistent": false
   },
   "commands": {
+    "selection-as-markdown": {
+      "description": "Copy Selection as Markdown"
+    },
     "current-tab-link": {
       "description": "current tab: [title](url)"
     },

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -33,6 +33,9 @@
     "type": "module"
   },
   "commands": {
+    "selection-as-markdown": {
+      "description": "Copy Selection as Markdown"
+    },
     "current-tab-link": {
       "description": "current tab: [title](url)"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "copy-as-markdown",
       "version": "2.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "turndown": "^7.1.3"
+      },
       "devDependencies": {
         "@types/chrome": "^0.0.200",
         "@types/firefox-webext-browser": "^94.0.1",
@@ -1280,6 +1284,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.192",
@@ -3836,6 +3845,14 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/turndown": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.3.tgz",
+      "integrity": "sha512-Z3/iJ6IWh8VBiACWQJaA5ulPQE5E1QwvBHj00uGzdQxdRnd8fh1DPqNOJqzQDu6DkOstORrtXzf/9adB+vMtEA==",
+      "dependencies": {
+        "domino": "^2.1.6"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5203,6 +5220,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "electron-to-chromium": {
       "version": "1.4.192",
@@ -7085,6 +7107,14 @@
         "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "turndown": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.3.tgz",
+      "integrity": "sha512-Z3/iJ6IWh8VBiACWQJaA5ulPQE5E1QwvBHj00uGzdQxdRnd8fh1DPqNOJqzQDu6DkOstORrtXzf/9adB+vMtEA==",
+      "requires": {
+        "domino": "^2.1.6"
       }
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "debug-firefox": "npx nodemon --exec 'sh compile.sh firefox' & npx web-ext run -s firefox/ --url about:debugging#/runtime/this-firefox https://example.com",
     "eslint": "eslint .",
     "clean": "rm -rf ./build/* firefox/dist/* firefox-mv2/dist/* chrome/dist/*",
-    "convert-images": "./utils/convert-images.sh"
+    "convert-images": "./utils/convert-images.sh",
+    "postinstall": "cp node_modules/turndown/dist/turndown.js src/vendor/"
   },
   "license": "MIT",
   "devDependencies": {
@@ -27,5 +28,8 @@
     "nodemon": "^2.0.19",
     "nyc": "^15.1.0",
     "typescript": "^2.9.2"
+  },
+  "dependencies": {
+    "turndown": "^7.1.3"
   }
 }

--- a/src/ui/about.md
+++ b/src/ui/about.md
@@ -41,3 +41,29 @@ Homepage: https://github.com/jgthms/bulma
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
+
+### Turndown.js
+
+Homepage: https://github.com/mixmark-io/turndown
+
+    MIT License
+
+    Copyright (c) 2017 Dom Christie
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.

--- a/src/vendor/turndown.js
+++ b/src/vendor/turndown.js
@@ -1,0 +1,973 @@
+var TurndownService = (function () {
+  'use strict';
+
+  function extend (destination) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        if (source.hasOwnProperty(key)) destination[key] = source[key];
+      }
+    }
+    return destination
+  }
+
+  function repeat (character, count) {
+    return Array(count + 1).join(character)
+  }
+
+  function trimLeadingNewlines (string) {
+    return string.replace(/^\n*/, '')
+  }
+
+  function trimTrailingNewlines (string) {
+    // avoid match-at-end regexp bottleneck, see #370
+    var indexEnd = string.length;
+    while (indexEnd > 0 && string[indexEnd - 1] === '\n') indexEnd--;
+    return string.substring(0, indexEnd)
+  }
+
+  var blockElements = [
+    'ADDRESS', 'ARTICLE', 'ASIDE', 'AUDIO', 'BLOCKQUOTE', 'BODY', 'CANVAS',
+    'CENTER', 'DD', 'DIR', 'DIV', 'DL', 'DT', 'FIELDSET', 'FIGCAPTION', 'FIGURE',
+    'FOOTER', 'FORM', 'FRAMESET', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HEADER',
+    'HGROUP', 'HR', 'HTML', 'ISINDEX', 'LI', 'MAIN', 'MENU', 'NAV', 'NOFRAMES',
+    'NOSCRIPT', 'OL', 'OUTPUT', 'P', 'PRE', 'SECTION', 'TABLE', 'TBODY', 'TD',
+    'TFOOT', 'TH', 'THEAD', 'TR', 'UL'
+  ];
+
+  function isBlock (node) {
+    return is(node, blockElements)
+  }
+
+  var voidElements = [
+    'AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT',
+    'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR'
+  ];
+
+  function isVoid (node) {
+    return is(node, voidElements)
+  }
+
+  function hasVoid (node) {
+    return has(node, voidElements)
+  }
+
+  var meaningfulWhenBlankElements = [
+    'A', 'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TH', 'TD', 'IFRAME', 'SCRIPT',
+    'AUDIO', 'VIDEO'
+  ];
+
+  function isMeaningfulWhenBlank (node) {
+    return is(node, meaningfulWhenBlankElements)
+  }
+
+  function hasMeaningfulWhenBlank (node) {
+    return has(node, meaningfulWhenBlankElements)
+  }
+
+  function is (node, tagNames) {
+    return tagNames.indexOf(node.nodeName) >= 0
+  }
+
+  function has (node, tagNames) {
+    return (
+      node.getElementsByTagName &&
+      tagNames.some(function (tagName) {
+        return node.getElementsByTagName(tagName).length
+      })
+    )
+  }
+
+  var rules = {};
+
+  rules.paragraph = {
+    filter: 'p',
+
+    replacement: function (content) {
+      return '\n\n' + content + '\n\n'
+    }
+  };
+
+  rules.lineBreak = {
+    filter: 'br',
+
+    replacement: function (content, node, options) {
+      return options.br + '\n'
+    }
+  };
+
+  rules.heading = {
+    filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+
+    replacement: function (content, node, options) {
+      var hLevel = Number(node.nodeName.charAt(1));
+
+      if (options.headingStyle === 'setext' && hLevel < 3) {
+        var underline = repeat((hLevel === 1 ? '=' : '-'), content.length);
+        return (
+          '\n\n' + content + '\n' + underline + '\n\n'
+        )
+      } else {
+        return '\n\n' + repeat('#', hLevel) + ' ' + content + '\n\n'
+      }
+    }
+  };
+
+  rules.blockquote = {
+    filter: 'blockquote',
+
+    replacement: function (content) {
+      content = content.replace(/^\n+|\n+$/g, '');
+      content = content.replace(/^/gm, '> ');
+      return '\n\n' + content + '\n\n'
+    }
+  };
+
+  rules.list = {
+    filter: ['ul', 'ol'],
+
+    replacement: function (content, node) {
+      var parent = node.parentNode;
+      if (parent.nodeName === 'LI' && parent.lastElementChild === node) {
+        return '\n' + content
+      } else {
+        return '\n\n' + content + '\n\n'
+      }
+    }
+  };
+
+  rules.listItem = {
+    filter: 'li',
+
+    replacement: function (content, node, options) {
+      content = content
+        .replace(/^\n+/, '') // remove leading newlines
+        .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
+        .replace(/\n/gm, '\n    '); // indent
+      var prefix = options.bulletListMarker + '   ';
+      var parent = node.parentNode;
+      if (parent.nodeName === 'OL') {
+        var start = parent.getAttribute('start');
+        var index = Array.prototype.indexOf.call(parent.children, node);
+        prefix = (start ? Number(start) + index : index + 1) + '.  ';
+      }
+      return (
+        prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '')
+      )
+    }
+  };
+
+  rules.indentedCodeBlock = {
+    filter: function (node, options) {
+      return (
+        options.codeBlockStyle === 'indented' &&
+        node.nodeName === 'PRE' &&
+        node.firstChild &&
+        node.firstChild.nodeName === 'CODE'
+      )
+    },
+
+    replacement: function (content, node, options) {
+      return (
+        '\n\n    ' +
+        node.firstChild.textContent.replace(/\n/g, '\n    ') +
+        '\n\n'
+      )
+    }
+  };
+
+  rules.fencedCodeBlock = {
+    filter: function (node, options) {
+      return (
+        options.codeBlockStyle === 'fenced' &&
+        node.nodeName === 'PRE' &&
+        node.firstChild &&
+        node.firstChild.nodeName === 'CODE'
+      )
+    },
+
+    replacement: function (content, node, options) {
+      var className = node.firstChild.getAttribute('class') || '';
+      var language = (className.match(/language-(\S+)/) || [null, ''])[1];
+      var code = node.firstChild.textContent;
+
+      var fenceChar = options.fence.charAt(0);
+      var fenceSize = 3;
+      var fenceInCodeRegex = new RegExp('^' + fenceChar + '{3,}', 'gm');
+
+      var match;
+      while ((match = fenceInCodeRegex.exec(code))) {
+        if (match[0].length >= fenceSize) {
+          fenceSize = match[0].length + 1;
+        }
+      }
+
+      var fence = repeat(fenceChar, fenceSize);
+
+      return (
+        '\n\n' + fence + language + '\n' +
+        code.replace(/\n$/, '') +
+        '\n' + fence + '\n\n'
+      )
+    }
+  };
+
+  rules.horizontalRule = {
+    filter: 'hr',
+
+    replacement: function (content, node, options) {
+      return '\n\n' + options.hr + '\n\n'
+    }
+  };
+
+  rules.inlineLink = {
+    filter: function (node, options) {
+      return (
+        options.linkStyle === 'inlined' &&
+        node.nodeName === 'A' &&
+        node.getAttribute('href')
+      )
+    },
+
+    replacement: function (content, node) {
+      var href = node.getAttribute('href');
+      var title = cleanAttribute(node.getAttribute('title'));
+      if (title) title = ' "' + title + '"';
+      return '[' + content + '](' + href + title + ')'
+    }
+  };
+
+  rules.referenceLink = {
+    filter: function (node, options) {
+      return (
+        options.linkStyle === 'referenced' &&
+        node.nodeName === 'A' &&
+        node.getAttribute('href')
+      )
+    },
+
+    replacement: function (content, node, options) {
+      var href = node.getAttribute('href');
+      var title = cleanAttribute(node.getAttribute('title'));
+      if (title) title = ' "' + title + '"';
+      var replacement;
+      var reference;
+
+      switch (options.linkReferenceStyle) {
+        case 'collapsed':
+          replacement = '[' + content + '][]';
+          reference = '[' + content + ']: ' + href + title;
+          break
+        case 'shortcut':
+          replacement = '[' + content + ']';
+          reference = '[' + content + ']: ' + href + title;
+          break
+        default:
+          var id = this.references.length + 1;
+          replacement = '[' + content + '][' + id + ']';
+          reference = '[' + id + ']: ' + href + title;
+      }
+
+      this.references.push(reference);
+      return replacement
+    },
+
+    references: [],
+
+    append: function (options) {
+      var references = '';
+      if (this.references.length) {
+        references = '\n\n' + this.references.join('\n') + '\n\n';
+        this.references = []; // Reset references
+      }
+      return references
+    }
+  };
+
+  rules.emphasis = {
+    filter: ['em', 'i'],
+
+    replacement: function (content, node, options) {
+      if (!content.trim()) return ''
+      return options.emDelimiter + content + options.emDelimiter
+    }
+  };
+
+  rules.strong = {
+    filter: ['strong', 'b'],
+
+    replacement: function (content, node, options) {
+      if (!content.trim()) return ''
+      return options.strongDelimiter + content + options.strongDelimiter
+    }
+  };
+
+  rules.code = {
+    filter: function (node) {
+      var hasSiblings = node.previousSibling || node.nextSibling;
+      var isCodeBlock = node.parentNode.nodeName === 'PRE' && !hasSiblings;
+
+      return node.nodeName === 'CODE' && !isCodeBlock
+    },
+
+    replacement: function (content) {
+      if (!content) return ''
+      content = content.replace(/\r?\n|\r/g, ' ');
+
+      var extraSpace = /^`|^ .*?[^ ].* $|`$/.test(content) ? ' ' : '';
+      var delimiter = '`';
+      var matches = content.match(/`+/gm) || [];
+      while (matches.indexOf(delimiter) !== -1) delimiter = delimiter + '`';
+
+      return delimiter + extraSpace + content + extraSpace + delimiter
+    }
+  };
+
+  rules.image = {
+    filter: 'img',
+
+    replacement: function (content, node) {
+      var alt = cleanAttribute(node.getAttribute('alt'));
+      var src = node.getAttribute('src') || '';
+      var title = cleanAttribute(node.getAttribute('title'));
+      var titlePart = title ? ' "' + title + '"' : '';
+      return src ? '![' + alt + ']' + '(' + src + titlePart + ')' : ''
+    }
+  };
+
+  function cleanAttribute (attribute) {
+    return attribute ? attribute.replace(/(\n+\s*)+/g, '\n') : ''
+  }
+
+  /**
+   * Manages a collection of rules used to convert HTML to Markdown
+   */
+
+  function Rules (options) {
+    this.options = options;
+    this._keep = [];
+    this._remove = [];
+
+    this.blankRule = {
+      replacement: options.blankReplacement
+    };
+
+    this.keepReplacement = options.keepReplacement;
+
+    this.defaultRule = {
+      replacement: options.defaultReplacement
+    };
+
+    this.array = [];
+    for (var key in options.rules) this.array.push(options.rules[key]);
+  }
+
+  Rules.prototype = {
+    add: function (key, rule) {
+      this.array.unshift(rule);
+    },
+
+    keep: function (filter) {
+      this._keep.unshift({
+        filter: filter,
+        replacement: this.keepReplacement
+      });
+    },
+
+    remove: function (filter) {
+      this._remove.unshift({
+        filter: filter,
+        replacement: function () {
+          return ''
+        }
+      });
+    },
+
+    forNode: function (node) {
+      if (node.isBlank) return this.blankRule
+      var rule;
+
+      if ((rule = findRule(this.array, node, this.options))) return rule
+      if ((rule = findRule(this._keep, node, this.options))) return rule
+      if ((rule = findRule(this._remove, node, this.options))) return rule
+
+      return this.defaultRule
+    },
+
+    forEach: function (fn) {
+      for (var i = 0; i < this.array.length; i++) fn(this.array[i], i);
+    }
+  };
+
+  function findRule (rules, node, options) {
+    for (var i = 0; i < rules.length; i++) {
+      var rule = rules[i];
+      if (filterValue(rule, node, options)) return rule
+    }
+    return void 0
+  }
+
+  function filterValue (rule, node, options) {
+    var filter = rule.filter;
+    if (typeof filter === 'string') {
+      if (filter === node.nodeName.toLowerCase()) return true
+    } else if (Array.isArray(filter)) {
+      if (filter.indexOf(node.nodeName.toLowerCase()) > -1) return true
+    } else if (typeof filter === 'function') {
+      if (filter.call(rule, node, options)) return true
+    } else {
+      throw new TypeError('`filter` needs to be a string, array, or function')
+    }
+  }
+
+  /**
+   * The collapseWhitespace function is adapted from collapse-whitespace
+   * by Luc Thevenard.
+   *
+   * The MIT License (MIT)
+   *
+   * Copyright (c) 2014 Luc Thevenard <lucthevenard@gmail.com>
+   *
+   * Permission is hereby granted, free of charge, to any person obtaining a copy
+   * of this software and associated documentation files (the "Software"), to deal
+   * in the Software without restriction, including without limitation the rights
+   * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   * copies of the Software, and to permit persons to whom the Software is
+   * furnished to do so, subject to the following conditions:
+   *
+   * The above copyright notice and this permission notice shall be included in
+   * all copies or substantial portions of the Software.
+   *
+   * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   * THE SOFTWARE.
+   */
+
+  /**
+   * collapseWhitespace(options) removes extraneous whitespace from an the given element.
+   *
+   * @param {Object} options
+   */
+  function collapseWhitespace (options) {
+    var element = options.element;
+    var isBlock = options.isBlock;
+    var isVoid = options.isVoid;
+    var isPre = options.isPre || function (node) {
+      return node.nodeName === 'PRE'
+    };
+
+    if (!element.firstChild || isPre(element)) return
+
+    var prevText = null;
+    var keepLeadingWs = false;
+
+    var prev = null;
+    var node = next(prev, element, isPre);
+
+    while (node !== element) {
+      if (node.nodeType === 3 || node.nodeType === 4) { // Node.TEXT_NODE or Node.CDATA_SECTION_NODE
+        var text = node.data.replace(/[ \r\n\t]+/g, ' ');
+
+        if ((!prevText || / $/.test(prevText.data)) &&
+            !keepLeadingWs && text[0] === ' ') {
+          text = text.substr(1);
+        }
+
+        // `text` might be empty at this point.
+        if (!text) {
+          node = remove(node);
+          continue
+        }
+
+        node.data = text;
+
+        prevText = node;
+      } else if (node.nodeType === 1) { // Node.ELEMENT_NODE
+        if (isBlock(node) || node.nodeName === 'BR') {
+          if (prevText) {
+            prevText.data = prevText.data.replace(/ $/, '');
+          }
+
+          prevText = null;
+          keepLeadingWs = false;
+        } else if (isVoid(node) || isPre(node)) {
+          // Avoid trimming space around non-block, non-BR void elements and inline PRE.
+          prevText = null;
+          keepLeadingWs = true;
+        } else if (prevText) {
+          // Drop protection if set previously.
+          keepLeadingWs = false;
+        }
+      } else {
+        node = remove(node);
+        continue
+      }
+
+      var nextNode = next(prev, node, isPre);
+      prev = node;
+      node = nextNode;
+    }
+
+    if (prevText) {
+      prevText.data = prevText.data.replace(/ $/, '');
+      if (!prevText.data) {
+        remove(prevText);
+      }
+    }
+  }
+
+  /**
+   * remove(node) removes the given node from the DOM and returns the
+   * next node in the sequence.
+   *
+   * @param {Node} node
+   * @return {Node} node
+   */
+  function remove (node) {
+    var next = node.nextSibling || node.parentNode;
+
+    node.parentNode.removeChild(node);
+
+    return next
+  }
+
+  /**
+   * next(prev, current, isPre) returns the next node in the sequence, given the
+   * current and previous nodes.
+   *
+   * @param {Node} prev
+   * @param {Node} current
+   * @param {Function} isPre
+   * @return {Node}
+   */
+  function next (prev, current, isPre) {
+    if ((prev && prev.parentNode === current) || isPre(current)) {
+      return current.nextSibling || current.parentNode
+    }
+
+    return current.firstChild || current.nextSibling || current.parentNode
+  }
+
+  /*
+   * Set up window for Node.js
+   */
+
+  var root = (typeof window !== 'undefined' ? window : {});
+
+  /*
+   * Parsing HTML strings
+   */
+
+  function canParseHTMLNatively () {
+    var Parser = root.DOMParser;
+    var canParse = false;
+
+    // Adapted from https://gist.github.com/1129031
+    // Firefox/Opera/IE throw errors on unsupported types
+    try {
+      // WebKit returns null on unsupported types
+      if (new Parser().parseFromString('', 'text/html')) {
+        canParse = true;
+      }
+    } catch (e) {}
+
+    return canParse
+  }
+
+  function createHTMLParser () {
+    var Parser = function () {};
+
+    {
+      if (shouldUseActiveX()) {
+        Parser.prototype.parseFromString = function (string) {
+          var doc = new window.ActiveXObject('htmlfile');
+          doc.designMode = 'on'; // disable on-page scripts
+          doc.open();
+          doc.write(string);
+          doc.close();
+          return doc
+        };
+      } else {
+        Parser.prototype.parseFromString = function (string) {
+          var doc = document.implementation.createHTMLDocument('');
+          doc.open();
+          doc.write(string);
+          doc.close();
+          return doc
+        };
+      }
+    }
+    return Parser
+  }
+
+  function shouldUseActiveX () {
+    var useActiveX = false;
+    try {
+      document.implementation.createHTMLDocument('').open();
+    } catch (e) {
+      if (root.ActiveXObject) useActiveX = true;
+    }
+    return useActiveX
+  }
+
+  var HTMLParser = canParseHTMLNatively() ? root.DOMParser : createHTMLParser();
+
+  function RootNode (input, options) {
+    var root;
+    if (typeof input === 'string') {
+      var doc = htmlParser().parseFromString(
+        // DOM parsers arrange elements in the <head> and <body>.
+        // Wrapping in a custom element ensures elements are reliably arranged in
+        // a single element.
+        '<x-turndown id="turndown-root">' + input + '</x-turndown>',
+        'text/html'
+      );
+      root = doc.getElementById('turndown-root');
+    } else {
+      root = input.cloneNode(true);
+    }
+    collapseWhitespace({
+      element: root,
+      isBlock: isBlock,
+      isVoid: isVoid,
+      isPre: options.preformattedCode ? isPreOrCode : null
+    });
+
+    return root
+  }
+
+  var _htmlParser;
+  function htmlParser () {
+    _htmlParser = _htmlParser || new HTMLParser();
+    return _htmlParser
+  }
+
+  function isPreOrCode (node) {
+    return node.nodeName === 'PRE' || node.nodeName === 'CODE'
+  }
+
+  function Node (node, options) {
+    node.isBlock = isBlock(node);
+    node.isCode = node.nodeName === 'CODE' || node.parentNode.isCode;
+    node.isBlank = isBlank(node);
+    node.flankingWhitespace = flankingWhitespace(node, options);
+    return node
+  }
+
+  function isBlank (node) {
+    return (
+      !isVoid(node) &&
+      !isMeaningfulWhenBlank(node) &&
+      /^\s*$/i.test(node.textContent) &&
+      !hasVoid(node) &&
+      !hasMeaningfulWhenBlank(node)
+    )
+  }
+
+  function flankingWhitespace (node, options) {
+    if (node.isBlock || (options.preformattedCode && node.isCode)) {
+      return { leading: '', trailing: '' }
+    }
+
+    var edges = edgeWhitespace(node.textContent);
+
+    // abandon leading ASCII WS if left-flanked by ASCII WS
+    if (edges.leadingAscii && isFlankedByWhitespace('left', node, options)) {
+      edges.leading = edges.leadingNonAscii;
+    }
+
+    // abandon trailing ASCII WS if right-flanked by ASCII WS
+    if (edges.trailingAscii && isFlankedByWhitespace('right', node, options)) {
+      edges.trailing = edges.trailingNonAscii;
+    }
+
+    return { leading: edges.leading, trailing: edges.trailing }
+  }
+
+  function edgeWhitespace (string) {
+    var m = string.match(/^(([ \t\r\n]*)(\s*))(?:(?=\S)[\s\S]*\S)?((\s*?)([ \t\r\n]*))$/);
+    return {
+      leading: m[1], // whole string for whitespace-only strings
+      leadingAscii: m[2],
+      leadingNonAscii: m[3],
+      trailing: m[4], // empty for whitespace-only strings
+      trailingNonAscii: m[5],
+      trailingAscii: m[6]
+    }
+  }
+
+  function isFlankedByWhitespace (side, node, options) {
+    var sibling;
+    var regExp;
+    var isFlanked;
+
+    if (side === 'left') {
+      sibling = node.previousSibling;
+      regExp = / $/;
+    } else {
+      sibling = node.nextSibling;
+      regExp = /^ /;
+    }
+
+    if (sibling) {
+      if (sibling.nodeType === 3) {
+        isFlanked = regExp.test(sibling.nodeValue);
+      } else if (options.preformattedCode && sibling.nodeName === 'CODE') {
+        isFlanked = false;
+      } else if (sibling.nodeType === 1 && !isBlock(sibling)) {
+        isFlanked = regExp.test(sibling.textContent);
+      }
+    }
+    return isFlanked
+  }
+
+  var reduce = Array.prototype.reduce;
+  var escapes = [
+    [/\\/g, '\\\\'],
+    [/\*/g, '\\*'],
+    [/^-/g, '\\-'],
+    [/^\+ /g, '\\+ '],
+    [/^(=+)/g, '\\$1'],
+    [/^(#{1,6}) /g, '\\$1 '],
+    [/`/g, '\\`'],
+    [/^~~~/g, '\\~~~'],
+    [/\[/g, '\\['],
+    [/\]/g, '\\]'],
+    [/^>/g, '\\>'],
+    [/_/g, '\\_'],
+    [/^(\d+)\. /g, '$1\\. ']
+  ];
+
+  function TurndownService (options) {
+    if (!(this instanceof TurndownService)) return new TurndownService(options)
+
+    var defaults = {
+      rules: rules,
+      headingStyle: 'setext',
+      hr: '* * *',
+      bulletListMarker: '*',
+      codeBlockStyle: 'indented',
+      fence: '```',
+      emDelimiter: '_',
+      strongDelimiter: '**',
+      linkStyle: 'inlined',
+      linkReferenceStyle: 'full',
+      br: '  ',
+      preformattedCode: false,
+      blankReplacement: function (content, node) {
+        return node.isBlock ? '\n\n' : ''
+      },
+      keepReplacement: function (content, node) {
+        return node.isBlock ? '\n\n' + node.outerHTML + '\n\n' : node.outerHTML
+      },
+      defaultReplacement: function (content, node) {
+        return node.isBlock ? '\n\n' + content + '\n\n' : content
+      }
+    };
+    this.options = extend({}, defaults, options);
+    this.rules = new Rules(this.options);
+  }
+
+  TurndownService.prototype = {
+    /**
+     * The entry point for converting a string or DOM node to Markdown
+     * @public
+     * @param {String|HTMLElement} input The string or DOM node to convert
+     * @returns A Markdown representation of the input
+     * @type String
+     */
+
+    turndown: function (input) {
+      if (!canConvert(input)) {
+        throw new TypeError(
+          input + ' is not a string, or an element/document/fragment node.'
+        )
+      }
+
+      if (input === '') return ''
+
+      var output = process.call(this, new RootNode(input, this.options));
+      return postProcess.call(this, output)
+    },
+
+    /**
+     * Add one or more plugins
+     * @public
+     * @param {Function|Array} plugin The plugin or array of plugins to add
+     * @returns The Turndown instance for chaining
+     * @type Object
+     */
+
+    use: function (plugin) {
+      if (Array.isArray(plugin)) {
+        for (var i = 0; i < plugin.length; i++) this.use(plugin[i]);
+      } else if (typeof plugin === 'function') {
+        plugin(this);
+      } else {
+        throw new TypeError('plugin must be a Function or an Array of Functions')
+      }
+      return this
+    },
+
+    /**
+     * Adds a rule
+     * @public
+     * @param {String} key The unique key of the rule
+     * @param {Object} rule The rule
+     * @returns The Turndown instance for chaining
+     * @type Object
+     */
+
+    addRule: function (key, rule) {
+      this.rules.add(key, rule);
+      return this
+    },
+
+    /**
+     * Keep a node (as HTML) that matches the filter
+     * @public
+     * @param {String|Array|Function} filter The unique key of the rule
+     * @returns The Turndown instance for chaining
+     * @type Object
+     */
+
+    keep: function (filter) {
+      this.rules.keep(filter);
+      return this
+    },
+
+    /**
+     * Remove a node that matches the filter
+     * @public
+     * @param {String|Array|Function} filter The unique key of the rule
+     * @returns The Turndown instance for chaining
+     * @type Object
+     */
+
+    remove: function (filter) {
+      this.rules.remove(filter);
+      return this
+    },
+
+    /**
+     * Escapes Markdown syntax
+     * @public
+     * @param {String} string The string to escape
+     * @returns A string with Markdown syntax escaped
+     * @type String
+     */
+
+    escape: function (string) {
+      return escapes.reduce(function (accumulator, escape) {
+        return accumulator.replace(escape[0], escape[1])
+      }, string)
+    }
+  };
+
+  /**
+   * Reduces a DOM node down to its Markdown string equivalent
+   * @private
+   * @param {HTMLElement} parentNode The node to convert
+   * @returns A Markdown representation of the node
+   * @type String
+   */
+
+  function process (parentNode) {
+    var self = this;
+    return reduce.call(parentNode.childNodes, function (output, node) {
+      node = new Node(node, self.options);
+
+      var replacement = '';
+      if (node.nodeType === 3) {
+        replacement = node.isCode ? node.nodeValue : self.escape(node.nodeValue);
+      } else if (node.nodeType === 1) {
+        replacement = replacementForNode.call(self, node);
+      }
+
+      return join(output, replacement)
+    }, '')
+  }
+
+  /**
+   * Appends strings as each rule requires and trims the output
+   * @private
+   * @param {String} output The conversion output
+   * @returns A trimmed version of the ouput
+   * @type String
+   */
+
+  function postProcess (output) {
+    var self = this;
+    this.rules.forEach(function (rule) {
+      if (typeof rule.append === 'function') {
+        output = join(output, rule.append(self.options));
+      }
+    });
+
+    return output.replace(/^[\t\r\n]+/, '').replace(/[\t\r\n\s]+$/, '')
+  }
+
+  /**
+   * Converts an element node to its Markdown equivalent
+   * @private
+   * @param {HTMLElement} node The node to convert
+   * @returns A Markdown representation of the node
+   * @type String
+   */
+
+  function replacementForNode (node) {
+    var rule = this.rules.forNode(node);
+    var content = process.call(this, node);
+    var whitespace = node.flankingWhitespace;
+    if (whitespace.leading || whitespace.trailing) content = content.trim();
+    return (
+      whitespace.leading +
+      rule.replacement(content, node, this.options) +
+      whitespace.trailing
+    )
+  }
+
+  /**
+   * Joins replacement to the current output with appropriate number of new lines
+   * @private
+   * @param {String} output The current conversion output
+   * @param {String} replacement The string to append to the output
+   * @returns Joined output
+   * @type String
+   */
+
+  function join (output, replacement) {
+    var s1 = trimTrailingNewlines(output);
+    var s2 = trimLeadingNewlines(replacement);
+    var nls = Math.max(output.length - s1.length, replacement.length - s2.length);
+    var separator = '\n\n'.substring(0, nls);
+
+    return s1 + separator + s2
+  }
+
+  /**
+   * Determines whether an input can be converted
+   * @private
+   * @param {String|HTMLElement} input Describe this parameter
+   * @returns Describe what it returns
+   * @type String|Object|Array|Boolean|Number
+   */
+
+  function canConvert (input) {
+    return (
+      input != null && (
+        typeof input === 'string' ||
+        (input.nodeType && (
+          input.nodeType === 1 || input.nodeType === 9 || input.nodeType === 11
+        ))
+      )
+    )
+  }
+
+  return TurndownService;
+
+}());

--- a/test/frameset.html
+++ b/test/frameset.html
@@ -1,0 +1,11 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<frameset cols="400, 500">
+    <frame src="iframe.html" />
+    <frame src="iframe.html" />
+</frameset>
+</html>

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -1,0 +1,12 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>iFrame Test</title>
+</head>
+<body>
+    <p>Lorem <i>ipsum</i> <b>dolor sit</b> <em>amet</em> <strong>consectetur</strong> <strong><em>adipisicing</em></strong> <a href="https://example.com">elit</a>. 
+        <code>Corrupti fugit</code> officia <img src="../artworks/icon.png" width="32" height="32" alt="ICON"> nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.</p>
+    
+</body>
+</html>

--- a/test/qa.html
+++ b/test/qa.html
@@ -16,5 +16,52 @@
   <p><img src="../artworks/icon.png" width="32" height="32" alt="ICON"></p>
   <p><a href="about:blank"><img src="../artworks/icon.png" width="32" height="32" alt="ICON"></a></p>
   <p><a href="about:blank"><img src="../artworks/icon.png" width="32" height="32" alt="ICON"> With Text</a></p>
+
+  <hr />
+
+  <h1>Test: Selection</h1>
+  <h2>Header 2</h2>
+  <h3>Header 3</h3>
+  <h4>Header 4</h4>
+  <h5>Header 5</h5>
+  <h6>Header 6</h6>
+
+  <p>Lorem <i>ipsum</i> <b>dolor sit</b> <em>amet</em> <strong>consectetur</strong> <strong><em>adipisicing</em></strong> <a href="https://example.com">elit</a>. 
+    <code>Corrupti fugit</code> officia <img src="../artworks/icon.png" width="32" height="32" alt="ICON"> nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.</p>
+
+  <hr />
+
+  <ul>
+    <li>Lorem</li>
+    <li><i>ipsum</i></li>
+    <li><b>dolor sit</b></li>
+    <li><em>amet</em></li>
+    <li>xyz
+      <ol>
+        <li><strong>consectetur</strong></li>
+        <li><strong><em>adipisicing</em></strong></li>
+        <li><a href="https://example.com">elit</a>    
+      </ol>
+    </li>
+  </ul>
+
+  <blockquote>
+    Lorem <i>ipsum</i> <b>dolor sit</b> <em>amet</em> <strong>consectetur</strong> <strong><em>adipisicing</em></strong> <a href="https://example.com">elit</a>. 
+      <code>Corrupti fugit</code> officia nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.
+  </blockquote>
+  
+  <pre><code>
+    Lorem ipsum dolor sit, amet consectetur adipisicing elit. 
+    Ratione nobis aperiam unde magni libero minima eaque at placeat 
+    molestiae odio! Ducimus ullam, nisi nostrum qui libero quidem culpa a ab.
+  </code></pre>
+
+  <h2>iFrame</h2>
+  <iframe src="iframe.html" frameborder="0"></iframe>
+
+  <!-- NOTE: clipboard API does not work in <FRAMESET>. It is a legacy Web feature. 
+    Leave unimplemented until someone asks for it. -->
+  <!-- <h2>Frameset</h2>
+  <a href="frameset.html">frameset.html</a> -->
 </body>
 </html>


### PR DESCRIPTION
## Summary

- A new context menu "Copy Selection as Markdown" that converts the selection on page as Markdown. Closes #82 
- A new keyboard shortcut item "Copy Selection as Markdown" that does the same thing above.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
