### PR TITLE
Resolve absolute URLs when copying selection as Markdown

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -118,6 +118,16 @@ function selectionToMarkdown(turndownOptions) {
   for (let i = 0, len = sel.rangeCount; i < len; i += 1) {
     container.appendChild(sel.getRangeAt(i).cloneContents());
   }
+
+  // Fix <a href> so that they are absolute URLs
+  container.querySelectorAll('a').forEach((value) => {
+    value.setAttribute('href', value.href);
+  });
+
+  // Fix <img src> so that they are absolute URLs
+  container.querySelectorAll('img').forEach((value) => {
+    value.setAttribute('src', value.src);
+  });
   const html = container.innerHTML;
   return turndownService.turndown(html);
 }


### PR DESCRIPTION
## Summary

- When copying selection as Markdown, modify the DOM tree so that `<a href>` and `<img src>` are all absolute URLs.

Closes #136 

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
