### PR TITLE
Firefox tabs context menu

### DIFF
--- a/firefox/create-menus.js
+++ b/firefox/create-menus.js
@@ -19,7 +19,10 @@ chrome.contextMenus.create({
   id: 'current-page',
   title: 'Copy Page Link as Markdown',
   type: 'normal',
-  contexts: ['page'],
+  contexts: [
+    'page',
+    'tab', // only available on Firefox
+  ],
 });
 
 chrome.contextMenus.create({
@@ -41,4 +44,46 @@ chrome.contextMenus.create({
   title: 'Copy Selection as Markdown',
   type: 'normal',
   contexts: ['selection'],
+});
+
+/* The following menu items are Firefox-only */
+
+browser.contextMenus.create({
+  id: 'separator-1',
+  type: 'separator',
+  contexts: ['tab'],
+});
+
+browser.contextMenus.create({
+  id: 'all-tabs-list',
+  title: 'Copy All Tabs',
+  type: 'normal',
+  contexts: ['tab'],
+});
+
+browser.contextMenus.create({
+  id: 'all-tabs-task-list',
+  title: 'Copy All Tabs (Task List)',
+  type: 'normal',
+  contexts: ['tab'],
+});
+
+browser.contextMenus.create({
+  id: 'separator-2',
+  type: 'separator',
+  contexts: ['tab'],
+});
+
+browser.contextMenus.create({
+  id: 'highlighted-tabs-list',
+  title: 'Copy Selected Tabs',
+  type: 'normal',
+  contexts: ['tab'],
+});
+
+browser.contextMenus.create({
+  id: 'highlighted-tabs-task-list',
+  title: 'Copy Selected Tabs (Task List)',
+  type: 'normal',
+  contexts: ['tab'],
 });

--- a/src/background.js
+++ b/src/background.js
@@ -210,6 +210,30 @@ async function handleContentOfContextMenu(info, tab) {
       break;
     }
 
+    // Only available on Firefox
+    case 'all-tabs-list': {
+      text = await handleExportTabs('all', 'link', 'list', tab.windowId);
+      break;
+    }
+
+    // Only available on Firefox
+    case 'all-tabs-task-list': {
+      text = await handleExportTabs('all', 'link', 'task-list', tab.windowId);
+      break;
+    }
+
+    // Only available on Firefox
+    case 'highlighted-tabs-list': {
+      text = await handleExportTabs('highlighted', 'link', 'list', tab.windowId);
+      break;
+    }
+
+    // Only available on Firefox
+    case 'highlighted-tabs-task-list': {
+      text = await handleExportTabs('highlighted', 'link', 'task-list', tab.windowId);
+      break;
+    }
+
     default: {
       throw new TypeError(`unknown context menu: ${info}`);
     }


### PR DESCRIPTION
## Summary

- Firefox: Adds context menus to the tab bar. Because it makes sense to have Copy Tab(s) as Markdown when right-clicking on the tabs. This feature is Firefox-only because there is no such API on Chrome.

<!-- briefly describe changes here -->
<img width="868" alt="截圖 2024-05-10 下午5 20 49" src="https://github.com/yorkxin/copy-as-markdown/assets/10737/f0f342d6-ed07-4d2f-b9db-21a473ed073e">


## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
