### PR TITLE
Make tabs & tabGroups optional features

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -9,12 +9,11 @@
     "alarms",
     "contextMenus",
     "scripting",
-    "storage",
-    "tabGroups",
-    "tabs"
+    "storage"
   ],
   "optional_permissions": [
-    "bookmarks"
+    "tabGroups",
+    "tabs"
   ],
   "action": {
     "default_icon": {
@@ -66,7 +65,8 @@
     }
   },
   "options_ui": {
-    "page": "./dist/ui/options.html"
+    "page": "./dist/ui/options.html",
+    "open_in_tab": true
   },
   "web_accessible_resources": [
     {

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/OptionsPage.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/OptionsPage.java
@@ -1,0 +1,22 @@
+package org.yorkxin.copyasmarkdown.e2e;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindAll;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.PageFactory;
+import java.util.List;
+
+// page_url = about:blank
+public class OptionsPage {
+    @FindBy(css = "[data-request-permission]")
+    public List<WebElement> requestButtons;
+
+    @FindBy(css = "[data-remove-permission]")
+    public List<WebElement> removeButtons;
+
+    public OptionsPage(WebDriver driver) {
+        PageFactory.initElements(driver, this);
+    }
+}

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/PermissionsPage.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/PermissionsPage.java
@@ -1,0 +1,20 @@
+package org.yorkxin.copyasmarkdown.e2e;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import java.util.List;
+
+// page_url = about:blank
+public class PermissionsPage {
+    @FindBy(id = "request-permission")
+    public WebElement requestButton;
+
+    @FindBy(id = "close")
+    public WebElement closeButton;
+
+    public PermissionsPage(WebDriver driver) {
+        PageFactory.initElements(driver, this);
+    }
+}

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/PermissionsPageTest.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/PermissionsPageTest.java
@@ -1,0 +1,71 @@
+package org.yorkxin.copyasmarkdown.e2e;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.Assert.*;
+
+public class PermissionsPageTest extends BaseTest {
+    private String permissionsWindowHandle;
+
+    public void openPermissionsPage() {
+        driver.switchTo().newWindow(WindowType.WINDOW);
+        permissionsWindowHandle = driver.getWindowHandle();
+        driver.get(getExtensionProtocol()+"://"+extId+"/dist/ui/permissions.html?permissions=tabs");
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        driver.switchTo().window(mainWindowHandle);
+    }
+
+    @Test
+    public void testRequestPermission() {
+        openPermissionsPage();
+        PermissionsPage page = new PermissionsPage(driver);
+        assertTrue(page.requestButton.isDisplayed());
+        assertTrue(page.requestButton.isEnabled());
+        assertEquals(page.requestButton.getText(), "Grant Permissions");
+
+        page.requestButton.click();
+        assertFalse(page.requestButton.isEnabled());
+
+        JavascriptExecutor js = (JavascriptExecutor) driver;
+        Boolean response = (Boolean) js.executeAsyncScript(
+                "var callback = arguments[arguments. length - 1];"+
+                "chrome.permissions.contains({ permissions: [\"tabs\"] }).then(callback);"
+        );
+        assertTrue(response);
+        driver.close();
+    }
+
+    @Test
+    public void testAlreadyGranted() {
+        grantPermission("tabs");
+        openPermissionsPage();
+        PermissionsPage page = new PermissionsPage(driver);
+        assertTrue(page.requestButton.isDisplayed());
+        assertFalse(page.requestButton.isEnabled());
+        assertEquals(page.requestButton.getText(), "Granted!");
+        driver.close();
+    }
+
+    @Test
+    public void testClose() {
+        openPermissionsPage();
+        PermissionsPage page = new PermissionsPage(driver);
+        assertTrue(page.closeButton.isDisplayed());
+        assertTrue(page.closeButton.isEnabled());
+        assertEquals(page.closeButton.getText(), "Close");
+
+        page.closeButton.click();
+        assertFalse(driver.getWindowHandles().contains(permissionsWindowHandle));
+    }
+}

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/keyboardshortcut/TabExportingTest.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/keyboardshortcut/TabExportingTest.java
@@ -2,6 +2,7 @@ package org.yorkxin.copyasmarkdown.e2e.keyboardshortcut;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -13,7 +14,7 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
 
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 public class TabExportingTest extends BaseTest {
     @BeforeClass
@@ -51,6 +52,7 @@ public class TabExportingTest extends BaseTest {
 
     @BeforeMethod
     public void setUp() {
+        grantPermission("tabs");
         openDemoTabs(false);
         driver.findElement(By.id("switch-to-demo")).click();
     }
@@ -61,9 +63,30 @@ public class TabExportingTest extends BaseTest {
         driver.findElement(By.id("close-demo")).click();
     }
 
+    private void testNoPermission(int[] modifiers, int key) throws AWTException {
+        // test that pressing keyboard shortcuts opens options page with error message,
+        // if tabs is not enabled
+        removePermission("tabs");
+        openDemoTabs(false);
+        driver.findElement(By.id("switch-to-demo")).click();
+
+        java.util.Set<String> windowsBefore = driver.getWindowHandles();
+        // smash the shortcut keys
+        runShortcutKeys(modifiers, key);
+
+        // assert that it opens one window, which is the permissions dialog
+        java.util.Set<String> windowsAfter = driver.getWindowHandles();
+        windowsAfter.removeAll(windowsBefore);
+        assertEquals(1, windowsAfter.size());
+        driver.switchTo().window(windowsAfter.iterator().next());
+        assertEquals(driver.getCurrentUrl(), getExtensionProtocol()+"://"+extId+"/dist/ui/permissions.html?permissions=tabs");
+    }
+
     @Test
     public void allTabsLink() throws AWTException, IOException, UnsupportedFlavorException, InterruptedException {
-        runShortcutKeys(new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT}, KeyEvent.VK_W);
+        int[] modifiers = new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT};
+        int key = KeyEvent.VK_W;
+        runShortcutKeys(modifiers, key);
 
         String expected = """
                   - [Page 0 - Copy as Markdown](http://localhost:5566/0.html)
@@ -74,11 +97,15 @@ public class TabExportingTest extends BaseTest {
                   - [Page 5 - Copy as Markdown](http://localhost:5566/5.html)""";
 
         assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+
+        testNoPermission(modifiers,key);
     }
 
     @Test
     public void allTabsTaskList() throws AWTException, IOException, UnsupportedFlavorException {
-        runShortcutKeys(new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT}, KeyEvent.VK_E);
+        int[] modifiers = new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT};
+        int key = KeyEvent.VK_E;
+        runShortcutKeys(modifiers, key);
 
         String expected = """
                   - [ ] [Page 0 - Copy as Markdown](http://localhost:5566/0.html)
@@ -89,11 +116,15 @@ public class TabExportingTest extends BaseTest {
                   - [ ] [Page 5 - Copy as Markdown](http://localhost:5566/5.html)""";
 
         assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+
+        testNoPermission(modifiers,key);
     }
 
     @Test
     public void allTabsTitle() throws AWTException, IOException, UnsupportedFlavorException {
-        runShortcutKeys(new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT}, KeyEvent.VK_R);
+        int[] modifiers = new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT};
+        int key = KeyEvent.VK_R;
+        runShortcutKeys(modifiers, key);
 
         String expected = """
                   - Page 0 - Copy as Markdown
@@ -104,11 +135,15 @@ public class TabExportingTest extends BaseTest {
                   - Page 5 - Copy as Markdown""";
 
         assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+
+        testNoPermission(modifiers,key);
     }
 
     @Test
     public void allTabsUrl() throws AWTException, IOException, UnsupportedFlavorException {
-        runShortcutKeys(new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT}, KeyEvent.VK_T);
+        int[] modifiers = new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT};
+        int key = KeyEvent.VK_T;
+        runShortcutKeys(modifiers, key);
 
         String expected = """
                   - http://localhost:5566/0.html
@@ -119,11 +154,15 @@ public class TabExportingTest extends BaseTest {
                   - http://localhost:5566/5.html""";
 
         assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+
+        testNoPermission(modifiers,key);
     }
 
     @Test
     public void highlightedTabsLink() throws AWTException, IOException, UnsupportedFlavorException, InterruptedException {
-        runShortcutKeys(new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT}, KeyEvent.VK_Y);
+        int[] modifiers = new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT};
+        int key = KeyEvent.VK_Y;
+        runShortcutKeys(modifiers, key);
 
         String expected = """
                 - [Page 0 - Copy as Markdown](http://localhost:5566/0.html)
@@ -131,11 +170,15 @@ public class TabExportingTest extends BaseTest {
                 - [Page 4 - Copy as Markdown](http://localhost:5566/4.html)""";
 
         assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+
+        testNoPermission(modifiers,key);
     }
 
     @Test
     public void highlightedTabsTaskList() throws AWTException, IOException, UnsupportedFlavorException {
-        runShortcutKeys(new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT}, KeyEvent.VK_U);
+        int[] modifiers = new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT};
+        int key = KeyEvent.VK_U;
+        runShortcutKeys(modifiers, key);
 
         String expected = """
                 - [ ] [Page 0 - Copy as Markdown](http://localhost:5566/0.html)
@@ -143,11 +186,15 @@ public class TabExportingTest extends BaseTest {
                 - [ ] [Page 4 - Copy as Markdown](http://localhost:5566/4.html)""";
 
         assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+
+        testNoPermission(modifiers,key);
     }
 
     @Test
     public void highlightedTabsTitle() throws AWTException, IOException, UnsupportedFlavorException {
-        runShortcutKeys(new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT}, KeyEvent.VK_I);
+        int[] modifiers = new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT};
+        int key = KeyEvent.VK_I;
+        runShortcutKeys(modifiers, key);
 
         String expected = """
                 - Page 0 - Copy as Markdown
@@ -155,11 +202,15 @@ public class TabExportingTest extends BaseTest {
                 - Page 4 - Copy as Markdown""";
 
         assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+
+        testNoPermission(modifiers,key);
     }
 
     @Test
     public void highlightedTabsUrl() throws AWTException, IOException, UnsupportedFlavorException {
-        runShortcutKeys(new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT}, KeyEvent.VK_O);
+        int[] modifiers = new int[]{KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT};
+                int key = KeyEvent.VK_O;
+                runShortcutKeys(modifiers, key);
 
         String expected = """
                 - http://localhost:5566/0.html
@@ -167,5 +218,7 @@ public class TabExportingTest extends BaseTest {
                 - http://localhost:5566/4.html""";
 
         assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+
+        testNoPermission(modifiers,key);
     }
 }

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/keyboardshortcut/TabExportingWithGroupsTest.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/keyboardshortcut/TabExportingWithGroupsTest.java
@@ -48,6 +48,8 @@ public class TabExportingWithGroupsTest extends BaseTest {
 
     @BeforeMethod
     public void setUp() {
+        grantPermission("tabs");
+        grantPermission("tabGroups");
         openDemoTabs(true);
         driver.findElement(By.id("switch-to-demo")).click();
     }

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/popup/PopupPage.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/popup/PopupPage.java
@@ -40,6 +40,9 @@ public class PopupPage {
     @FindBy(id = "highlighted-tabs-url")
     public WebElement highlightedTabsUrlButton;
 
+    @FindBy(id = "enable-tabs-feature")
+    public WebElement enableTabsFeatureButton;
+
     public PopupPage(WebDriver driver) {
         PageFactory.initElements(driver, this);
     }

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/popup/SimpleTest.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/popup/SimpleTest.java
@@ -1,31 +1,35 @@
 package org.yorkxin.copyasmarkdown.e2e.popup;
 
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 import org.yorkxin.copyasmarkdown.e2e.DemoPageData;
 
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 public class SimpleTest extends BaseTest {
-    @BeforeMethod
-    public void setUp() {
+    @Test
+    public void counter()  {
         DemoPageData dpd = openDemoTabs(false);
         openPopupWindow(dpd);
-    }
-
-    @Test
-    public void counter() throws IOException, UnsupportedFlavorException {
+        Assert.assertTrue(popupPage.counterAll.isDisplayed());
+        Assert.assertTrue(popupPage.counterHighlighted.isDisplayed());
         Assert.assertEquals("6", popupPage.counterAll.getText());
         Assert.assertEquals("3", popupPage.counterHighlighted.getText());
     }
 
     @Test
     public void currentTabLink() throws IOException, UnsupportedFlavorException, InterruptedException {
+        // XXX: because the popup is using chrome.tabs.query() to get tab with id from parameter,
+        // it is necessary to grant the 'tabs' permission. Technically, 'activeTab' is the tab that opens the popup window.
+        // In the actual Chrome / Firefox, 'tabs' permission is not required to get title / url of the current tab.
+        grantPermission("tabs");
+
+        DemoPageData dpd = openDemoTabs(false);
+        openPopupWindow(dpd);
         popupPage.currentTabLinkButton.click();
         Thread.sleep(1000);
         String expected = "[Page 0 - Copy as Markdown](http://localhost:5566/0.html)";

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/popup/TabExportingTest.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/popup/TabExportingTest.java
@@ -1,24 +1,49 @@
 package org.yorkxin.copyasmarkdown.e2e.popup;
 
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.yorkxin.copyasmarkdown.e2e.DemoPageData;
 
+import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 public class TabExportingTest extends BaseTest {
     @BeforeMethod
     public void setUp() {
+        grantPermission("tabs");
         DemoPageData dpd = openDemoTabs(false);
         openPopupWindow(dpd);
     }
 
+    private void testNoPermission(WebElement button) throws AWTException {
+        // test that pressing keyboard shortcuts opens options page with error message,
+        // if tabs is not enabled
+        removePermission("tabs");
+        DemoPageData dpd = openDemoTabs(false);
+        openPopupWindow(dpd);
+
+        java.util.Set<String> windowsBefore = driver.getWindowHandles();
+        button.click();
+
+        // assert that it opens one window, which is the permissions dialog
+        java.util.Set<String> windowsAfter = driver.getWindowHandles();
+        windowsAfter.removeAll(windowsBefore);
+        assertEquals(1, windowsAfter.size());
+        driver.switchTo().window(windowsAfter.iterator().next());
+        assertEquals(driver.getCurrentUrl(), getExtensionProtocol()+"://"+extId+"/dist/ui/permissions.html?permissions=tabs");
+        driver.close();
+        driver.switchTo().window(mainWindowHandle);
+    }
+
     @Test
-    public void allTabsAsList() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void allTabsAsList() throws IOException, UnsupportedFlavorException, InterruptedException, AWTException {
+        assertTrue(popupPage.allTabsListButton.isDisplayed());
         popupPage.allTabsListButton.click();
         Thread.sleep(1000);
         String expected = """
@@ -29,10 +54,12 @@ public class TabExportingTest extends BaseTest {
                 - [Page 4 - Copy as Markdown](http://localhost:5566/4.html)
                 - [Page 5 - Copy as Markdown](http://localhost:5566/5.html)""";
         assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
+        testNoPermission(popupPage.allTabsListButton);
     }
 
     @Test
-    public void allTabsAsTaskList() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void allTabsAsTaskList() throws IOException, UnsupportedFlavorException, InterruptedException, AWTException {
+        assertTrue(popupPage.allTabsTaskListButton.isDisplayed());
         popupPage.allTabsTaskListButton.click();
         Thread.sleep(1000);
         String expected = """
@@ -43,10 +70,12 @@ public class TabExportingTest extends BaseTest {
                 - [ ] [Page 4 - Copy as Markdown](http://localhost:5566/4.html)
                 - [ ] [Page 5 - Copy as Markdown](http://localhost:5566/5.html)""";
         assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
+        testNoPermission(popupPage.allTabsTaskListButton);
     }
 
     @Test
-    public void allTabsAsTitleList() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void allTabsAsTitleList() throws IOException, UnsupportedFlavorException, InterruptedException, AWTException {
+        assertTrue(popupPage.allTabsTitleButton.isDisplayed());
         popupPage.allTabsTitleButton.click();
         Thread.sleep(1000);
         String expected = """
@@ -57,10 +86,12 @@ public class TabExportingTest extends BaseTest {
                 - Page 4 - Copy as Markdown
                 - Page 5 - Copy as Markdown""";
         assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
+        testNoPermission(popupPage.allTabsTitleButton);
     }
 
     @Test
-    public void allTabsAsUrlList() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void allTabsAsUrlList() throws IOException, UnsupportedFlavorException, InterruptedException, AWTException {
+        assertTrue(popupPage.allTabsUrlButton.isDisplayed());
         popupPage.allTabsUrlButton.click();
         Thread.sleep(1000);
         String expected = """
@@ -71,10 +102,12 @@ public class TabExportingTest extends BaseTest {
                 - http://localhost:5566/4.html
                 - http://localhost:5566/5.html""";
         assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
+        testNoPermission(popupPage.allTabsUrlButton);
     }
 
     @Test
-    public void highlightedTabsAsList() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void highlightedTabsAsList() throws IOException, UnsupportedFlavorException, InterruptedException, AWTException {
+        assertTrue(popupPage.highlightedTabsListButton.isDisplayed());
         popupPage.highlightedTabsListButton.click();
         Thread.sleep(1000);
         String expected = """
@@ -82,10 +115,12 @@ public class TabExportingTest extends BaseTest {
                 - [Page 2 - Copy as Markdown](http://localhost:5566/2.html)
                 - [Page 4 - Copy as Markdown](http://localhost:5566/4.html)""";
         assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
+        testNoPermission(popupPage.highlightedTabsListButton);
     }
 
     @Test
-    public void highlightedTabsAsTaskList() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void highlightedTabsAsTaskList() throws IOException, UnsupportedFlavorException, InterruptedException, AWTException {
+        assertTrue(popupPage.highlightedTabsTaskListButton.isDisplayed());
         popupPage.highlightedTabsTaskListButton.click();
         Thread.sleep(1000);
         String expected = """
@@ -93,10 +128,12 @@ public class TabExportingTest extends BaseTest {
                 - [ ] [Page 2 - Copy as Markdown](http://localhost:5566/2.html)
                 - [ ] [Page 4 - Copy as Markdown](http://localhost:5566/4.html)""";
         assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
+        testNoPermission(popupPage.highlightedTabsTaskListButton);
     }
 
     @Test
-    public void highlightedTabsAsTitleList() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void highlightedTabsAsTitleList() throws IOException, UnsupportedFlavorException, InterruptedException, AWTException {
+        assertTrue(popupPage.highlightedTabsTitleButton.isDisplayed());
         popupPage.highlightedTabsTitleButton.click();
         Thread.sleep(1000);
         String expected = """
@@ -104,10 +141,12 @@ public class TabExportingTest extends BaseTest {
                 - Page 2 - Copy as Markdown
                 - Page 4 - Copy as Markdown""";
         assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
+        testNoPermission(popupPage.highlightedTabsTitleButton);
     }
 
     @Test
-    public void highlightedTabsAsUrlList() throws IOException, UnsupportedFlavorException, InterruptedException {
+    public void highlightedTabsAsUrlList() throws IOException, UnsupportedFlavorException, InterruptedException, AWTException {
+        assertTrue(popupPage.highlightedTabsUrlButton.isDisplayed());
         popupPage.highlightedTabsUrlButton.click();
         Thread.sleep(1000);
         String expected = """
@@ -115,5 +154,6 @@ public class TabExportingTest extends BaseTest {
                 - http://localhost:5566/2.html
                 - http://localhost:5566/4.html""";
         assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
+        testNoPermission(popupPage.highlightedTabsUrlButton);
     }
 }

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/popup/TabExportingWithGroupsTest.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/popup/TabExportingWithGroupsTest.java
@@ -1,6 +1,5 @@
 package org.yorkxin.copyasmarkdown.e2e.popup;
 
-import org.openqa.selenium.By;
 import org.testng.annotations.*;
 import org.yorkxin.copyasmarkdown.e2e.DemoPageData;
 
@@ -13,6 +12,8 @@ import java.io.IOException;
 public class TabExportingWithGroupsTest extends org.yorkxin.copyasmarkdown.e2e.popup.BaseTest {
     @BeforeMethod
     public void setUp() {
+        grantPermission("tabs");
+        grantPermission("tabGroups");
         DemoPageData dpd = openDemoTabs(true);
         openPopupWindow(dpd);
     }

--- a/firefox/create-menus.js
+++ b/firefox/create-menus.js
@@ -54,38 +54,67 @@ browser.contextMenus.create({
   contexts: ['tab'],
 });
 
-browser.contextMenus.create({
-  id: 'all-tabs-list',
-  title: 'Copy All Tabs',
-  type: 'normal',
-  contexts: ['tab'],
+function addTabsContextMenu() {
+  browser.contextMenus.create({
+    id: 'all-tabs-list',
+    title: 'Copy All Tabs',
+    type: 'normal',
+    contexts: ['tab'],
+  });
+
+  browser.contextMenus.create({
+    id: 'all-tabs-task-list',
+    title: 'Copy All Tabs (Task List)',
+    type: 'normal',
+    contexts: ['tab'],
+  });
+
+  browser.contextMenus.create({
+    id: 'separator-2',
+    type: 'separator',
+    contexts: ['tab'],
+  });
+
+  browser.contextMenus.create({
+    id: 'highlighted-tabs-list',
+    title: 'Copy Selected Tabs',
+    type: 'normal',
+    contexts: ['tab'],
+  });
+
+  browser.contextMenus.create({
+    id: 'highlighted-tabs-task-list',
+    title: 'Copy Selected Tabs (Task List)',
+    type: 'normal',
+    contexts: ['tab'],
+  });
+}
+
+async function removeTabsContextMenu() {
+  await browser.contextMenus.remove('all-tabs-list');
+  await browser.contextMenus.remove('all-tabs-task-list');
+  await browser.contextMenus.remove('separator-2');
+  await browser.contextMenus.remove('highlighted-tabs-list');
+  await browser.contextMenus.remove('highlighted-tabs-task-list');
+}
+
+browser.permissions.contains({ permissions: ['tabs'] })
+  .then((ok) => {
+    if (ok) {
+      addTabsContextMenu();
+    }
+  });
+
+browser.permissions.onAdded.addListener((e) => {
+  if (e.permissions.includes('tabs')) {
+    addTabsContextMenu();
+  }
 });
 
-browser.contextMenus.create({
-  id: 'all-tabs-task-list',
-  title: 'Copy All Tabs (Task List)',
-  type: 'normal',
-  contexts: ['tab'],
-});
-
-browser.contextMenus.create({
-  id: 'separator-2',
-  type: 'separator',
-  contexts: ['tab'],
-});
-
-browser.contextMenus.create({
-  id: 'highlighted-tabs-list',
-  title: 'Copy Selected Tabs',
-  type: 'normal',
-  contexts: ['tab'],
-});
-
-browser.contextMenus.create({
-  id: 'highlighted-tabs-task-list',
-  title: 'Copy Selected Tabs (Task List)',
-  type: 'normal',
-  contexts: ['tab'],
+browser.permissions.onRemoved.addListener(async (e) => {
+  if (e.permissions.includes('tabs')) {
+    await removeTabsContextMenu();
+  }
 });
 
 chrome.contextMenus.create({

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -9,11 +9,11 @@
     "contextMenus",
     "clipboardWrite",
     "scripting",
-    "storage",
-    "tabs"
+    "storage"
   ],
   "optional_permissions": [
-    "bookmarks"
+    "bookmarks",
+    "tabs"
   ],
   "browser_action": {
     "default_icon": {
@@ -65,7 +65,8 @@
     }
   },
   "options_ui": {
-    "page": "./dist/ui/options.html"
+    "page": "./dist/ui/options.html",
+    "open_in_tab": true
   },
   "browser_specific_settings": {
     "gecko": {

--- a/src/background.js
+++ b/src/background.js
@@ -197,8 +197,22 @@ async function handleExportTabs(scope, format, listType, windowId) {
     windowId,
   };
 
+  if (!await WebExt.permissions.allGranted(['tabs'])) {
+    await chrome.windows.create({
+      focused: true,
+      type: 'popup',
+      width: 640,
+      height: 480,
+      url: '/dist/ui/permissions.html?permissions=tabs',
+    });
+    throw new Error('permission required');
+  }
+
   /** @type {chrome.tabGroups.TabGroup[]} */
-  const crGroups = Object.hasOwn(chrome, 'tabGroups') ? await chrome.tabGroups.query({ windowId }) : [];
+  let crGroups = [];
+  if (await WebExt.permissions.contain('tabGroups') === 'yes') {
+    crGroups = await chrome.tabGroups.query({ windowId });
+  }
   const crTabs = await asyncTabsQuery(query);
 
   // Everything above depends on chrome|browser

--- a/src/ui/options.html
+++ b/src/ui/options.html
@@ -6,62 +6,62 @@
   <link rel="stylesheet" href="../vendor/bulma.css">
 </head>
 <body>
-<div class="container content is-fluid">
-  <h2>Style</h2>
-  <form id='form-style-of-unordered-list' class="field">
-    <label class="label">Unordered List Character</label>
-    <div class="control">
-      <label class="radio">
-        <input type="radio" name="character" value="dash" />
-        Dashes (<code>-</code>)
-      </label>
-    </div>
-    <div class="control">
-      <label class="radio">
-        <input type="radio" name="character" value="asterisk" />
-        Asterisks (<code>*</code>)
-      </label>
-    </div>
-    <div class="control">
-      <label class="radio">
-        <input type="radio" name="character" value="plus" />
-        Plus Signs (<code>+</code>)
-      </label>
-    </div>
-  </form>
-  <form id='form-style-of-tab-group-indentation' class="field">
-    <label class="label">Tab Group Indentation</label>
-    <div class="control">
-      <label class="radio">
-        <input type="radio" name="indentation" value="spaces" />
-        Spaces
-      </label>
-    </div>
-    <div class="control">
-      <label class="radio">
-        <input type="radio" name="indentation" value="tab" />
-        Tab
-      </label>
-    </div>
-    <p class="help">
-      CommonMark uses spaces to indent nested lists, which are used when exporting tabs along with tab groups.
-      The number of spaces required depends on the leading characters of the parent item.
-      If your Markdown processor prefers <kbd>tab</kbd> (<code>\t</code>) characters for indentation,
-      choose <strong>Tab</strong> so that Copy as Markdown outputs tabs for indentation.
-      Please note that this option does not affect indentations in the output of Copy Selection as Markdown.
-    </p>
-  </form>
-  <hr/>
-  <h2>Bookmarks Integration <span class="tag" data-permission-status="bookmarks">Disabled</span></h2>
-  <p>Enable context menus on bookmarks (Firefox-only).</p>
-  <button class="button is-small is-outlined is-primary" data-permission-request="bookmarks">Enable Bookmarks Integration</button>
-  <button class="button is-small is-outlined is-danger" data-permission-remove="bookmarks">Disable Bookmarks Integration</button>
-  <hr/>
-  <h2>Advanced</h2>
-  <form id="form-link-text-always-escape-brackets" class="field">    
-      <label class="label">Always escape brackets in link text</label>
+<div class="container section content is-max-desktop">
+  <h1 class="title">Copy as Markdown</h1>
+  <div id="flash-error" class="notification is-danger is-hidden">
+    <p></p>
+  </div>
+  <div class="box">
+    <h2>Markdown Style</h2>
+    <form id='form-style-of-unordered-list' class="field">
+      <label class="label">Unordered List Character</label>
       <div class="control">
-        <label class="checkbox"><input type="checkbox" name="enabled" /> Enabled (<code>[]</code> becomes <code>\[\]</code>)</label>
+        <label class="radio">
+          <input type="radio" name="character" value="dash" />
+          Dashes (<code>-</code>)
+        </label>
+      </div>
+      <div class="control">
+        <label class="radio">
+          <input type="radio" name="character" value="asterisk" />
+          Asterisks (<code>*</code>)
+        </label>
+      </div>
+      <div class="control">
+        <label class="radio">
+          <input type="radio" name="character" value="plus" />
+          Plus Signs (<code>+</code>)
+        </label>
+      </div>
+    </form>
+
+    <form id='form-style-of-tab-group-indentation' class="field">
+      <label class="label">Tab Group Indentation <span class="tag" data-hide-if-permission-contains="tabGroups">Requires Permission</span></label>
+      <div class="control">
+        <label class="radio">
+          <input type="radio" name="indentation" value="spaces" data-dependson-permissions="tabGroups" />
+          Spaces
+        </label>
+      </div>
+      <div class="control">
+        <label class="radio">
+          <input type="radio" name="indentation" value="tab" data-dependson-permissions="tabGroups" />
+          Tab
+        </label>
+      </div>
+      <p class="help">
+        CommonMark uses spaces to indent nested lists, which are used when exporting tabs along with tab groups.
+        The number of spaces required depends on the leading characters of the parent item.
+        If your Markdown processor prefers <kbd>tab</kbd> (<code>\t</code>) characters for indentation,
+        choose <strong>Tab</strong> so that Copy as Markdown outputs tabs for indentation.
+        Please note that this option does not affect indentations in the output of Copy Selection as Markdown.
+      </p>
+    </form>
+
+    <h3>Escaping</h3>
+    <form id="form-link-text-always-escape-brackets" class="field">
+      <div class="control">
+        <label class="checkbox"><input type="checkbox" name="enabled" /> Always escape brackets in link text (<code>[]</code> becomes <code>\[\]</code>)</label>
       </div>
       <p class="help">
         CommonMark allows balanced brackets <code>[]</code> in link text
@@ -69,16 +69,35 @@
         If your Markdown processor does not support this use case, you can enable this feature
         so that Copy as Markdown always escape brackets in the link text.
       </p>
-
-  </form>
-
-  <hr />
-  <div class="field mb-4">
-    <button id="reset" type="button" class="button is-small">Reset to Default</button>
-    <a href="about.md" target="_blank" class="button is-small is-text">About</a>
+    </form>
   </div>
-</div>
 
+  <div class="box">
+    <h2>Additional Permissions</h2>
+    <p>Some features require additional permissions. Prompts will appear when permissions are not granted.</p>
+    <h3>Tabs <span class="tag" data-hide-if-permission-contains="tabs">Not Granted</span></h3>
+    <p>Copy all / selected tabs via the popup menu and shortcut keys. Also, via context menus on tabs (Firefox-only).</p>
+    <div class="field">
+      <button class="button is-small is-outlined is-primary" data-request-permission="tabs">Grant Tabs Permission</button>
+      <button class="button is-small is-outlined is-danger" data-remove-permission="tabs">Revoke Tabs Permission</button>
+    </div>
+
+    <h4>Tab Groups <span class="tag" data-hide-if-permission-contains="tabGroups">Not Granted</span></h4>
+    <p>(Chrome-only) Wrap tabs in your tab groups. Need to grant Tabs permission above.</p>
+    <div class="field">
+      <button class="button is-small is-outlined is-primary" data-request-permission="tabGroups">Grant Tab Groups Permission</button>
+      <button class="button is-small is-outlined is-danger" data-remove-permission="tabGroups">Revoke Tab Groups Permission</button>
+    </div>
+
+    <h3>Bookmarks <span class="tag" data-hide-if-permission-contains="bookmarks">Not Granted</span></h3>
+    <p>Enable context menus on bookmarks (Firefox-only).</p>
+    <div class="field">
+      <button class="button is-small is-outlined is-primary" data-request-permission="bookmarks">Grant Bookmarks Permission</button>
+      <button class="button is-small is-outlined is-danger" data-remove-permission="bookmarks">Revoke Bookmarks Permission</button>
+    </div>
+  </div>
+  <button id="reset" type="button" class="button is-small is-outlined is-danger">Reset to Default</button>
+</div>
   <script src="./options.js" type="module"></script>
 </body>
 </html>

--- a/src/ui/permissions.html
+++ b/src/ui/permissions.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Copy as Markdown - Permission Required</title>
+    <link rel="stylesheet" href="../vendor/bulma.css">
+</head>
+<body>
+<div class="container section content">
+    <h1>Copy as Markdown - Permission Required</h1>
+    <p>The feature you are going to use requires additional permissions: <code id="permissions-placeholder"></code>. Please grant permissions to use it.</p>
+    <p>You may revoke permission at anytime on the <a href="./options.html" target="_blank">Options</a> page.</p>
+    <button id="request-permission" class="button is-primary">Grant Permissions</button>
+    <button id="close" class="button">Close</button>
+</div>
+<script src="./permissions.js" type="module"></script>
+</body>
+</html>

--- a/src/ui/permissions.js
+++ b/src/ui/permissions.js
@@ -1,0 +1,22 @@
+import { WebExt } from '../webext.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const paramPermissions = new URLSearchParams(window.location.search).get('permissions').split(',');
+
+  document.getElementById('close').addEventListener('click', () => {
+    window.close();
+  });
+
+  document.getElementById('permissions-placeholder').textContent = paramPermissions.join(', ');
+
+  const grantButton = document.getElementById('request-permission');
+  if (await WebExt.permissions.allGranted(paramPermissions)) {
+    grantButton.disabled = true;
+    grantButton.innerText = 'Granted!';
+  } else {
+    grantButton.addEventListener('click', async () => {
+      await WebExt.permissions.request(paramPermissions);
+      window.location.reload();
+    });
+  }
+});

--- a/src/webext.js
+++ b/src/webext.js
@@ -23,3 +23,129 @@ export class WebExt {
     });
   }
 }
+
+WebExt.storage = {
+  session: {
+    /**
+     *
+     * @param keys {string|string[]}
+     * @returns {Promise<Object<string,any>>}
+     */
+    async get(keys) {
+      return new Promise((resolve, reject) => {
+        try {
+          chrome.storage.session.get(keys, (ok) => {
+            resolve(ok);
+          });
+        } catch (e) {
+          reject(e);
+        }
+      });
+    },
+    /**
+     * @param {Object<string,any>} items
+     * @return {Promise<null>}
+     */
+    async set(items) {
+      return new Promise((resolve, reject) => {
+        try {
+          chrome.storage.session.set(items, () => {
+            resolve(null);
+          });
+        } catch (e) {
+          reject(e);
+        }
+      });
+    },
+    /**
+     * @param {string|string[]} keys
+     * @return {Promise<null>}
+     */
+    async remove(keys) {
+      return new Promise((resolve, reject) => {
+        try {
+          chrome.storage.session.remove(keys, () => {
+            resolve(null);
+          });
+        } catch (e) {
+          reject(e);
+        }
+      });
+    },
+  },
+};
+
+WebExt.permissions = {
+  /**
+   *
+   * @param permission {string}
+   * @returns {Promise<'yes','no','unavailable'>}
+   */
+  async contain(permission) {
+    return new Promise((resolve) => {
+      const optionalPermissions = chrome.runtime.getManifest().optional_permissions;
+
+      if (optionalPermissions && !optionalPermissions.find((e) => e === permission)) {
+        resolve('unavailable');
+      }
+
+      try {
+        chrome.permissions.contains({ permissions: [permission] }, (ok) => {
+          if (ok) {
+            resolve('yes');
+          }
+
+          resolve('no');
+        });
+      } catch (e) {
+        resolve('unavailable');
+      }
+    });
+  },
+
+  /**
+   *
+   * @param permissions {string[]}
+   * @return {Promise<boolean>}
+   */
+  async allGranted(permissions) {
+    const statuses = await Promise.all(permissions.map((perm) => this.contain(perm)));
+    return statuses.every((status) => status === 'yes');
+  },
+
+  /**
+   * chrome.permissions in Firefox MV2 does not return a Promise, so wraps the API with Promise.
+   *
+   * @param permissions {string[]}
+   * @returns {Promise<boolean>}
+   */
+  async request(permissions) {
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.permissions.request({ permissions }, (ok) => {
+          resolve(ok);
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+  },
+
+  /**
+   * chrome.permissions in Firefox MV2 does not return a Promise, so wraps the API with Promise.
+   *
+   * @param permissions {string[]}
+   * @returns {Promise<boolean>}
+   */
+  async remove(permissions) {
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.permissions.remove({ permissions }, (ok) => {
+          resolve(ok);
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+  },
+};


### PR DESCRIPTION
## Summary

* Making `tabs` and `tabGroups` optional permissions, so that users are informed when the extension requires additional permissions.

Related: #148 


## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
