### PR TITLE
Fix: Popup writes "undefined" when missing tabs permission

### DIFF
--- a/src/ui/popup.js
+++ b/src/ui/popup.js
@@ -34,6 +34,7 @@ document.forms['form-popup-actions'].addEventListener('submit', (e) => {
           window.close();
         }
       });
+      return;
     }
 
     navigator.clipboard.writeText(response.text)


### PR DESCRIPTION
## Summary

<!-- briefly describe changes here -->

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
