### PR TITLE
Restore context menus on tabs on Firefox

### DIFF
--- a/firefox/create-menus.js
+++ b/firefox/create-menus.js
@@ -54,67 +54,38 @@ browser.contextMenus.create({
   contexts: ['tab'],
 });
 
-function addTabsContextMenu() {
-  browser.contextMenus.create({
-    id: 'all-tabs-list',
-    title: 'Copy All Tabs',
-    type: 'normal',
-    contexts: ['tab'],
-  });
-
-  browser.contextMenus.create({
-    id: 'all-tabs-task-list',
-    title: 'Copy All Tabs (Task List)',
-    type: 'normal',
-    contexts: ['tab'],
-  });
-
-  browser.contextMenus.create({
-    id: 'separator-2',
-    type: 'separator',
-    contexts: ['tab'],
-  });
-
-  browser.contextMenus.create({
-    id: 'highlighted-tabs-list',
-    title: 'Copy Selected Tabs',
-    type: 'normal',
-    contexts: ['tab'],
-  });
-
-  browser.contextMenus.create({
-    id: 'highlighted-tabs-task-list',
-    title: 'Copy Selected Tabs (Task List)',
-    type: 'normal',
-    contexts: ['tab'],
-  });
-}
-
-async function removeTabsContextMenu() {
-  await browser.contextMenus.remove('all-tabs-list');
-  await browser.contextMenus.remove('all-tabs-task-list');
-  await browser.contextMenus.remove('separator-2');
-  await browser.contextMenus.remove('highlighted-tabs-list');
-  await browser.contextMenus.remove('highlighted-tabs-task-list');
-}
-
-browser.permissions.contains({ permissions: ['tabs'] })
-  .then((ok) => {
-    if (ok) {
-      addTabsContextMenu();
-    }
-  });
-
-browser.permissions.onAdded.addListener((e) => {
-  if (e.permissions.includes('tabs')) {
-    addTabsContextMenu();
-  }
+browser.contextMenus.create({
+  id: 'all-tabs-list',
+  title: 'Copy All Tabs',
+  type: 'normal',
+  contexts: ['tab'],
 });
 
-browser.permissions.onRemoved.addListener(async (e) => {
-  if (e.permissions.includes('tabs')) {
-    await removeTabsContextMenu();
-  }
+browser.contextMenus.create({
+  id: 'all-tabs-task-list',
+  title: 'Copy All Tabs (Task List)',
+  type: 'normal',
+  contexts: ['tab'],
+});
+
+browser.contextMenus.create({
+  id: 'separator-2',
+  type: 'separator',
+  contexts: ['tab'],
+});
+
+browser.contextMenus.create({
+  id: 'highlighted-tabs-list',
+  title: 'Copy Selected Tabs',
+  type: 'normal',
+  contexts: ['tab'],
+});
+
+browser.contextMenus.create({
+  id: 'highlighted-tabs-task-list',
+  title: 'Copy Selected Tabs (Task List)',
+  type: 'normal',
+  contexts: ['tab'],
 });
 
 chrome.contextMenus.create({


### PR DESCRIPTION
## Summary

- Permissions dialog will appear when needed. Displaying the menu items also hints the user that such feature exists.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
