### PR TITLE
Remove embedded <style> and <script> tags

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="JavaScriptLibraryMappings">
-    <file url="file://$PROJECT_DIR$" libraries="{copy-as-markdown/node_modules}" />
-    <file url="PROJECT" libraries="{copy-as-markdown/node_modules}" />
-    <includedPredefinedLibrary name="Node.js Core" />
-  </component>
-</project>

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/ContextMenuTest.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/ContextMenuTest.java
@@ -10,6 +10,9 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.KeyEvent;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Objects;
 
 public class ContextMenuTest extends BaseTest {
@@ -158,6 +161,9 @@ public class ContextMenuTest extends BaseTest {
 
     @Test
     public void onPageSelection() throws AWTException, InterruptedException, IOException, UnsupportedFlavorException {
+        Path filePath = Paths.get("support/pages/selection.md");
+        String expected = Files.readString(filePath);
+
         // navigate to selection.html
         driver.findElement(By.id("go-to-selection")).click();
         selectAll();
@@ -196,39 +202,9 @@ public class ContextMenuTest extends BaseTest {
         robot.keyPress(KeyEvent.VK_N);
         robot.keyPress(KeyEvent.VK_ENTER);
         Thread.sleep(500);
-        String expected = """
-                # Test: Selection
-                                
-                ## Header 2
-                                
-                ### Header 3
-                                
-                #### Header 4
-                                
-                ##### Header 5
-                                
-                ###### Header 6
-                                
-                Lorem _ipsum_ **dolor sit** _amet_ **consectetur** **_adipisicing_** [elit](https://example.com/). `Corrupti fugit` officia ![ICON](http://localhost:5566/icon.png) nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.
-                                
-                * * *
-                                
-                -   Lorem
-                -   _ipsum_
-                -   **dolor sit**
-                -   _amet_
-                -   xyz
-                    1.  **consectetur**
-                    2.  **_adipisicing_**
-                    3.  [elit](https://example.com/)
-                                
-                > Lorem _ipsum_ **dolor sit** _amet_ **consectetur** **_adipisicing_** [elit](https://example.com/). `Corrupti fugit` officia nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.
-                                
-                   \s
-                        Lorem ipsum dolor sit, amet consectetur adipisicing elit.\s
-                        Ratione nobis aperiam unde magni libero minima eaque at placeat\s
-                        molestiae odio! Ducimus ullam, nisi nostrum qui libero quidem culpa a ab.""";
-        assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+        // NOTE: in the selection.md file, there is a line with only four space chars right below a code block.
+        // This is expected and is part of the test case, because the original <pre><code> is ended with a new line.
+        assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
     }
 
     // In Chrome, context menu items more than 1 will be folded in a sub menu with extension's name.

--- a/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/keyboardshortcut/OnPageContentsTest.java
+++ b/e2e/src/test/java/org/yorkxin/copyasmarkdown/e2e/keyboardshortcut/OnPageContentsTest.java
@@ -7,6 +7,9 @@ import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.testng.Assert.assertEquals;
 import static org.yorkxin.copyasmarkdown.e2e.keyboardshortcut.tabs.BaseTest.getCommandDescriptor;
@@ -48,6 +51,9 @@ public class OnPageContentsTest extends BaseTest{
 
     @Test
     public void copySelectionAsMarkdown () throws AWTException, IOException, UnsupportedFlavorException, InterruptedException {
+        Path filePath = Paths.get("support/pages/selection.md");
+        String expected = Files.readString(filePath);
+
         CommandDescriptor cmd = getCommandDescriptor("selection-as-markdown");
         configureKeyboardShortcuts(new CommandDescriptor[]{cmd});
 
@@ -56,39 +62,9 @@ public class OnPageContentsTest extends BaseTest{
         runShortcutKeys(cmd.getRobotModifiers(), cmd.getRobotKey());
         Thread.sleep(500);
 
-        String expected = """
-                # Test: Selection
-                                
-                ## Header 2
-                                
-                ### Header 3
-                                
-                #### Header 4
-                                
-                ##### Header 5
-                                
-                ###### Header 6
-                                
-                Lorem _ipsum_ **dolor sit** _amet_ **consectetur** **_adipisicing_** [elit](https://example.com/). `Corrupti fugit` officia ![ICON](http://localhost:5566/icon.png) nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.
-                                
-                * * *
-                                
-                -   Lorem
-                -   _ipsum_
-                -   **dolor sit**
-                -   _amet_
-                -   xyz
-                    1.  **consectetur**
-                    2.  **_adipisicing_**
-                    3.  [elit](https://example.com/)
-                                
-                > Lorem _ipsum_ **dolor sit** _amet_ **consectetur** **_adipisicing_** [elit](https://example.com/). `Corrupti fugit` officia nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.
-                                
-                   \s
-                        Lorem ipsum dolor sit, amet consectetur adipisicing elit.\s
-                        Ratione nobis aperiam unde magni libero minima eaque at placeat\s
-                        molestiae odio! Ducimus ullam, nisi nostrum qui libero quidem culpa a ab.""";
-        assertEquals(expected, clipboard.getData(DataFlavor.stringFlavor));
+        // NOTE: in the selection.md file, there is a line with only four space chars right below a code block.
+        // This is expected and is part of the test case, because the original <pre><code> is ended with a new line.
+        assertEquals(clipboard.getData(DataFlavor.stringFlavor),expected);
     }
 
 

--- a/e2e/support/pages/selection.html
+++ b/e2e/support/pages/selection.html
@@ -8,7 +8,7 @@
   <h1>Test: Selection</h1>
   <h2>Header 2</h2>
   <h3>Header 3</h3>
-  <h4>Header 4</h4>
+  <h4>Header 4<script>console.log('hello world')</script></h4>
   <h5>Header 5</h5>
   <h6>Header 6</h6>
 
@@ -35,11 +35,16 @@
     Lorem <i>ipsum</i> <b>dolor sit</b> <em>amet</em> <strong>consectetur</strong> <strong><em>adipisicing</em></strong> <a href="https://example.com">elit</a>. 
       <code>Corrupti fugit</code> officia nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.
   </blockquote>
-  
-  <pre><code>
-    Lorem ipsum dolor sit, amet consectetur adipisicing elit. 
-    Ratione nobis aperiam unde magni libero minima eaque at placeat 
+
+<pre><code>Lorem ipsum dolor sit, amet consectetur adipisicing elit.
+  Ratione nobis aperiam unde magni libero minima eaque at placeat
     molestiae odio! Ducimus ullam, nisi nostrum qui libero quidem culpa a ab.
-  </code></pre>
+</code></pre>
+
+  <!--from Wikipedia https://en.wikipedia.org/wiki/Markdown -->
+  <p>In March 2016, two relevant informational Internet <a href="/wiki/Request_for_Comments" title="Request for Comments">RFCs</a> were published:
+  </p>
+  <ul><li><style data-mw-deduplicate="TemplateStyles:r1238218222">.mw-parser-output cite.citation{font-style:inherit;word-wrap:break-word}.mw-parser-output .citation q{quotes:"\"""\"""'""'"}.mw-parser-output .citation:target{background-color:rgba(0,127,255,0.133)}.mw-parser-output .id-lock-free.id-lock-free a{background:url("//upload.wikimedia.org/wikipedia/commons/6/65/Lock-green.svg")right 0.1em center/9px no-repeat}.mw-parser-output .id-lock-limited.id-lock-limited a,.mw-parser-output .id-lock-registration.id-lock-registration a{background:url("//upload.wikimedia.org/wikipedia/commons/d/d6/Lock-gray-alt-2.svg")right 0.1em center/9px no-repeat}.mw-parser-output .id-lock-subscription.id-lock-subscription a{background:url("//upload.wikimedia.org/wikipedia/commons/a/aa/Lock-red-alt-2.svg")right 0.1em center/9px no-repeat}.mw-parser-output .cs1-ws-icon a{background:url("//upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg")right 0.1em center/12px no-repeat}body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-free a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-limited a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-registration a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-subscription a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .cs1-ws-icon a{background-size:contain;padding:0 1em 0 0}.mw-parser-output .cs1-code{color:inherit;background:inherit;border:none;padding:inherit}.mw-parser-output .cs1-hidden-error{display:none;color:var(--color-error,#d33)}.mw-parser-output .cs1-visible-error{color:var(--color-error,#d33)}.mw-parser-output .cs1-maint{display:none;color:#085;margin-left:0.3em}.mw-parser-output .cs1-kern-left{padding-left:0.2em}.mw-parser-output .cs1-kern-right{padding-right:0.2em}.mw-parser-output .citation .mw-selflink{font-weight:inherit}@media screen{.mw-parser-output .cs1-format{font-size:95%}html.skin-theme-clientpref-night .mw-parser-output .cs1-maint{color:#18911f}}@media screen and (prefers-color-scheme:dark){html.skin-theme-clientpref-os .mw-parser-output .cs1-maint{color:#18911f}}</style>RFC&nbsp;<a rel="nofollow" class="external text" href="https://datatracker.ietf.org/doc/html/rfc7763">7763</a> introduced <a href="/wiki/MIME" title="MIME">MIME</a> type <small><code class="mw-highlight mw-highlight-lang-text mw-content-ltr" style="" dir="ltr">text/markdown</code></small>.</li>
+    <li><link rel="mw-deduplicated-inline-style" href="mw-data:TemplateStyles:r1238218222">RFC&nbsp;<a rel="nofollow" class="external text" href="https://datatracker.ietf.org/doc/html/rfc7764">7764</a> discussed and registered the variants <a href="/wiki/MultiMarkdown" title="MultiMarkdown">MultiMarkdown</a>, GitHub Flavored Markdown (GFM), <a href="/wiki/Pandoc" title="Pandoc">Pandoc</a>, and Markdown Extra among others.<sup id="cite_ref-IANA_31-0" class="reference"><a href="#cite_note-IANA-31"><span class="cite-bracket">[</span>30<span class="cite-bracket">]</span></a></sup></li></ul>
 </body>
 </html>

--- a/e2e/support/pages/selection.md
+++ b/e2e/support/pages/selection.md
@@ -1,0 +1,36 @@
+# Test: Selection
+
+## Header 2
+
+### Header 3
+
+#### Header 4
+
+##### Header 5
+
+###### Header 6
+
+Lorem _ipsum_ **dolor sit** _amet_ **consectetur** **_adipisicing_** [elit](https://example.com/). `Corrupti fugit` officia ![ICON](http://localhost:5566/icon.png) nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.
+
+* * *
+
+-   Lorem
+-   _ipsum_
+-   **dolor sit**
+-   _amet_
+-   xyz
+    1.  **consectetur**
+    2.  **_adipisicing_**
+    3.  [elit](https://example.com/)
+
+> Lorem _ipsum_ **dolor sit** _amet_ **consectetur** **_adipisicing_** [elit](https://example.com/). `Corrupti fugit` officia nemo porro nam ipsam dignissimos aliquid harum officiis consectetur quasi quaerat quis repellat minus eveniet aspernatur, ratione dolorum natus.
+
+    Lorem ipsum dolor sit, amet consectetur adipisicing elit.
+      Ratione nobis aperiam unde magni libero minima eaque at placeat
+        molestiae odio! Ducimus ullam, nisi nostrum qui libero quidem culpa a ab.
+    
+
+In March 2016, two relevant informational Internet [RFCs](http://localhost:5566/wiki/Request_for_Comments "Request for Comments") were published:
+
+-   RFC [7763](https://datatracker.ietf.org/doc/html/rfc7763) introduced [MIME](http://localhost:5566/wiki/MIME "MIME") type `text/markdown`.
+-   RFC [7764](https://datatracker.ietf.org/doc/html/rfc7764) discussed and registered the variants [MultiMarkdown](http://localhost:5566/wiki/MultiMarkdown "MultiMarkdown"), GitHub Flavored Markdown (GFM), [Pandoc](http://localhost:5566/wiki/Pandoc "Pandoc"), and Markdown Extra among others.[\[30\]](http://localhost:5566/selection.html#cite_note-IANA-31)

--- a/src/background.js
+++ b/src/background.js
@@ -242,7 +242,9 @@ browser.alarms.onAlarm.addListener(async (alarm) => {
 // NOTE: this function should be executed in content script.
 function selectionToMarkdown(turndownOptions) {
   // eslint-disable-next-line no-undef
-  const turndownService = new TurndownService(turndownOptions);
+  const turndownService = new TurndownService(turndownOptions)
+    .remove('script')
+    .remove('style');
   const sel = getSelection();
   const container = document.createElement('div');
   for (let i = 0, len = sel.rangeCount; i < len; i += 1) {


### PR DESCRIPTION
## Summary

Reported by https://github.com/yorkxin/copy-as-markdown/issues/163

When copying selection as Markdown, when there are embedded `<style>` and `<script>` tags in the dom, they should be removed from the result Markdown.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
