### PR TITLE
Firefox tab groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ firefox-mv3/dist/*
 !firefox-mv3/dist/.keep
 firefox/dist/*
 !firefox/dist/.keep
+firefox-deved/dist/*
+!firefox-deved/dist/.keep
 chrome/dist/*
 !chrome/dist/.keep
 .nyc_output

--- a/e2e_test/test_tabs_exporting.py
+++ b/e2e_test/test_tabs_exporting.py
@@ -320,10 +320,6 @@ class TestTabsExporting:
         "all-tabs-custom-format-2",
     ])
     def test_all_tabs_grouped_keyboard_shortcut(self, manifest_key: str):
-        if self.browser.brand == "firefox":
-            # The extension does not support grouped tabs in Firefox
-            pytest.skip("Firefox does not support grouped tabs")
-
         kbd = self.all_keyboard_shortcuts.get_by_manifest_key(manifest_key)
         expected_format = self.ALL_TABS_GROUPED_FORMATS[manifest_key]
         self.browser.set_grouped_tabs()
@@ -346,10 +342,6 @@ class TestTabsExporting:
         "highlighted-tabs-custom-format-2",
     ])
     def test_highlighted_tabs_grouped_keyboard_shortcut(self, manifest_key: str):
-        if self.browser.brand == "firefox":
-            # The extension does not support grouped tabs in Firefox
-            pytest.skip("Firefox does not support grouped tabs")
-
         kbd = self.all_keyboard_shortcuts.get_by_manifest_key(manifest_key)
         expected_format = self.HIGHLIGHTED_TABS_GROUPED_FORMATS[manifest_key]
         self.browser.set_grouped_tabs()
@@ -373,10 +365,6 @@ class TestTabsExporting:
         "all-tabs-custom-format-2",
     ])
     def test_all_tabs_grouped_popup_menu(self, manifest_key: str):
-        if self.browser.brand == "firefox":
-            # The extension does not support grouped tabs in Firefox
-            pytest.skip("Firefox does not support grouped tabs")
-
         expected_format = self.ALL_TABS_GROUPED_FORMATS[manifest_key]
         self.browser.set_grouped_tabs()
         for ul_style, prefix in self.ALL_UNORDERED_LIST_STYLES.items():
@@ -398,10 +386,6 @@ class TestTabsExporting:
         "highlighted-tabs-custom-format-2",
     ])
     def test_highlighted_tabs_grouped_popup_menu(self, manifest_key: str):
-        if self.browser.brand == "firefox":
-            # The extension does not support grouped tabs in Firefox
-            pytest.skip("Firefox does not support grouped tabs")
-
         expected_format = self.HIGHLIGHTED_TABS_GROUPED_FORMATS[manifest_key]
         self.browser.set_grouped_tabs()
         self.browser.set_highlighted_tabs()

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -13,7 +13,8 @@
   ],
   "optional_permissions": [
     "bookmarks",
-    "tabs"
+    "tabs",
+    "tabGroups"
   ],
   "browser_action": {
     "default_icon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,10 +186,11 @@
       "dev": true
     },
     "node_modules/@types/firefox-webext-browser": {
-      "version": "120.0.3",
-      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-120.0.3.tgz",
-      "integrity": "sha512-APbBSxOvFMbKwXy/4YrEVa5Di6N0C9yl4w0WA0xzdkOrChAfPQ/KlcC8QLyhemHCHpF1CB/zHy52+oUQurViOg==",
-      "dev": true
+      "version": "120.0.4",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-120.0.4.tgz",
+      "integrity": "sha512-lBrpf08xhiZBigrtdQfUaqX1UauwZ+skbFiL8u2Tdra/rklkKadYmIzTwkNZSWtuZ7OKpFqbE2HHfDoFqvZf6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/har-format": {
       "version": "1.2.15",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "debug-edge": "node scripts/debug.js edge",
     "debug-firefox-mv3": "node scripts/debug.js firefox-mv3",
     "debug-firefox": "node scripts/debug.js firefox",
+    "debug-firefox-deved": "node scripts/debug.js firefox-deved",
     "eslint": "eslint .",
     "clean": "rm -rf ./build/* firefox/dist/* firefox-mv3/dist/* chrome/dist/*",
     "convert-images": "./scripts/convert-images.sh",

--- a/scripts/debug.js
+++ b/scripts/debug.js
@@ -47,6 +47,11 @@ switch (browser) {
     // eslint-disable-next-line camelcase
     spawnedBrowser = child_process.exec(`npx web-ext run -s ${path.join(root, 'firefox')} --url about:debugging#/runtime/this-firefox https://example.com`);
     break;
+  case 'firefox-deved':
+    console.log('starting firefox developer edition');
+    // eslint-disable-next-line camelcase
+    spawnedBrowser = child_process.exec(`npx web-ext run -f deved -s ${path.join(root, 'firefox')} --url about:debugging#/runtime/this-firefox https://example.com`);
+    break;
   case 'firefox-mv3':
     console.log('starting firefox-mv3');
     // eslint-disable-next-line camelcase

--- a/src/background.js
+++ b/src/background.js
@@ -300,7 +300,7 @@ function formatItems(tabLists, formatter) {
 /**
  *
  * @param windowId {Number}
- * @returns {Promise<chrome.tabGroups.TabGroup[]>}
+ * @returns {Promise<browser.tabGroups.TabGroup[]>}
  */
 async function getTabGroups(windowId) {
   let granted = false;
@@ -315,7 +315,7 @@ async function getTabGroups(windowId) {
     return [];
   }
 
-  return chrome.tabGroups.query({ windowId });
+  return browser.tabGroups.query({ windowId });
 }
 
 /**

--- a/src/ui/options-permissions.html
+++ b/src/ui/options-permissions.html
@@ -26,7 +26,7 @@
         </div>
 
         <h4>Tab Groups <span class="tag" data-hide-if-permission-contains="tabGroups">Not Granted</span></h4>
-        <p>(Chrome-only) Wrap tabs in your tab groups. Need to grant Tabs permission above.</p>
+        <p>Wrap tabs in your tab groups. Need to grant Tabs permission above.</p>
         <div class="field">
           <button class="button is-small is-outlined is-primary" data-request-permission="tabGroups">Grant Tab Groups Permission</button>
           <button class="button is-small is-outlined is-danger" data-remove-permission="tabGroups">Revoke Tab Groups Permission</button>


### PR DESCRIPTION
## Summary

Firefox supports tab groups API since 139, so it's time to turn on the tab groups feature in Copy as Markdown.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
