### PR TITLE
Add environment variable to force browser download for Selenium

### DIFF
--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -1,5 +1,6 @@
 import ctypes
 import re
+import subprocess
 import sys
 from textwrap import dedent
 import time
@@ -215,6 +216,7 @@ class BrowserEnvironment:
         shadow = Shadow(self.driver)
 
         for shortcut in keyboard_shortcuts.items:
+            # XXX: this only works for Chrome running in English language.
             element = shadow.find_element(f"[aria-label=\"Edit shortcut {shortcut.label} for Copy as Markdown\"]")
             self.driver.execute_script("arguments[0].scrollIntoView(true);", element)
             element.click()
@@ -375,6 +377,11 @@ def browser_environment(request):
         browser = request.param
 
         if browser == "chrome":
+            # on macOS, force the language to English
+            if sys.platform == 'darwin':
+                # run a command to set the language to English
+                subprocess.run(["defaults", "write", "com.google.chrome.for.testing", "AppleLanguages", "-array", "en"])
+
             options = webdriver.ChromeOptions()
             # options.add_argument("--headless=new")  # use headless new mode
             options.add_argument("--disable-gpu")


### PR DESCRIPTION
## Summary

This is necessary because Google-branded Chrome can have different behaviors with Chrome for Test. The latter does not have too much Google stuffs, and allows load-extension arguments.

See https://issues.chromium.org/issues/401529219

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [x] Chrome stable (Windows)
- [x] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
