### PR TITLE
Workaround firefox shortcuts

### DIFF
--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -220,9 +220,7 @@ class BrowserEnvironment:
             element = shadow.find_element(f"[aria-label=\"Edit shortcut {shortcut.label} for Copy as Markdown\"]")
             self.driver.execute_script("arguments[0].scrollIntoView(true);", element)
             element.click()
-            key = shortcut.keystroke
-            actions = ActionChains(self.driver)
-            actions.key_down(Keys.ALT).key_down(Keys.SHIFT).send_keys(key).key_up(Keys.SHIFT).key_up(Keys.ALT).perform()
+            shortcut.run_action_chain(ActionChains(self.driver)).perform()
         
         self.driver.close()
         self.driver.switch_to.window(original_window)
@@ -260,8 +258,7 @@ class BrowserEnvironment:
             ActionChains(self.driver).click(cmd_entry).perform()
 
             # Execute key combination
-            actions = ActionChains(self.driver)
-            actions.key_down(Keys.ALT).key_down(Keys.SHIFT).send_keys(shortcut.keystroke).key_up(Keys.SHIFT).key_up(Keys.ALT).perform()
+            shortcut.run_action_chain(ActionChains(self.driver)).perform()
 
         self.driver.close()
         self.driver.switch_to.window(original_window)

--- a/e2e_test/keyboard_shortcuts.py
+++ b/e2e_test/keyboard_shortcuts.py
@@ -48,22 +48,27 @@ ALL_SHORTCUTS = {
     "current-tab-custom-format-5": Shortcut(label="current tab: custom format 5", manifest_key="current-tab-custom-format-5", keystroke="7"),
     "all-tabs-link-as-list": Shortcut(label="all tabs: - [title](url)", manifest_key="all-tabs-link-as-list", keystroke="8"),
     "all-tabs-link-as-task-list": Shortcut(label="all tabs: - [ ] [title](url)", manifest_key="all-tabs-link-as-task-list", keystroke="9"),
-    "all-tabs-title-as-list": Shortcut(label="all tabs: - title", manifest_key="all-tabs-title-as-list", keystroke="q"),
-    "all-tabs-url-as-list": Shortcut(label="all tabs: - url", manifest_key="all-tabs-url-as-list", keystroke="w"),
-    "highlighted-tabs-link-as-list": Shortcut(label="selected tabs: - [title](url)", manifest_key="highlighted-tabs-link-as-list", keystroke="e"),
-    "highlighted-tabs-link-as-task-list": Shortcut(label="selected tabs: - [ ] [title](url)", manifest_key="highlighted-tabs-link-as-task-list", keystroke="r"),
-    "highlighted-tabs-title-as-list": Shortcut(label="selected tabs: - title", manifest_key="highlighted-tabs-title-as-list", keystroke="t"),
-    "highlighted-tabs-url-as-list": Shortcut(label="selected tabs: - url", manifest_key="highlighted-tabs-url-as-list", keystroke="y"),
-    "all-tabs-custom-format-1": Shortcut(label="all tabs: custom format 1", manifest_key="all-tabs-custom-format-1", keystroke="u"),
-    "all-tabs-custom-format-2": Shortcut(label="all tabs: custom format 2", manifest_key="all-tabs-custom-format-2", keystroke="i"),
-    "all-tabs-custom-format-3": Shortcut(label="all tabs: custom format 3", manifest_key="all-tabs-custom-format-3", keystroke="o"),
-    "all-tabs-custom-format-4": Shortcut(label="all tabs: custom format 4", manifest_key="all-tabs-custom-format-4", keystroke="p"),
-    "all-tabs-custom-format-5": Shortcut(label="all tabs: custom format 5", manifest_key="all-tabs-custom-format-5", keystroke="a"),
-    "highlighted-tabs-custom-format-1": Shortcut(label="selected tabs: custom format 1", manifest_key="highlighted-tabs-custom-format-1", keystroke="s"),
-    "highlighted-tabs-custom-format-2": Shortcut(label="selected tabs: custom format 2", manifest_key="highlighted-tabs-custom-format-2", keystroke="d"),
-    "highlighted-tabs-custom-format-3": Shortcut(label="selected tabs: custom format 3", manifest_key="highlighted-tabs-custom-format-3", keystroke="f"),
-    "highlighted-tabs-custom-format-4": Shortcut(label="selected tabs: custom format 4", manifest_key="highlighted-tabs-custom-format-4", keystroke="g"),
-    "highlighted-tabs-custom-format-5": Shortcut(label="selected tabs: custom format 5", manifest_key="highlighted-tabs-custom-format-5", keystroke="h")
+    "all-tabs-title-as-list": Shortcut(label="all tabs: - title", manifest_key="all-tabs-title-as-list", keystroke="a"),
+    # skipping b to avoid conflict with Firefox's menu shortcut
+    "all-tabs-url-as-list": Shortcut(label="all tabs: - url", manifest_key="all-tabs-url-as-list", keystroke="c"),
+    "highlighted-tabs-link-as-list": Shortcut(label="selected tabs: - [title](url)", manifest_key="highlighted-tabs-link-as-list", keystroke="d"),
+    # skipping e and f to avoid conflict with Firefox's menu shortcut
+    "highlighted-tabs-link-as-task-list": Shortcut(label="selected tabs: - [ ] [title](url)", manifest_key="highlighted-tabs-link-as-task-list", keystroke="g"),
+    # skipping h to avoid conflict with Firefox's menu shortcut
+    "highlighted-tabs-title-as-list": Shortcut(label="selected tabs: - title", manifest_key="highlighted-tabs-title-as-list", keystroke="i"),
+    "highlighted-tabs-url-as-list": Shortcut(label="selected tabs: - url", manifest_key="highlighted-tabs-url-as-list", keystroke="j"),
+    "all-tabs-custom-format-1": Shortcut(label="all tabs: custom format 1", manifest_key="all-tabs-custom-format-1", keystroke="k"),
+    "all-tabs-custom-format-2": Shortcut(label="all tabs: custom format 2", manifest_key="all-tabs-custom-format-2", keystroke="l"),
+    "all-tabs-custom-format-3": Shortcut(label="all tabs: custom format 3", manifest_key="all-tabs-custom-format-3", keystroke="m"),
+    "all-tabs-custom-format-4": Shortcut(label="all tabs: custom format 4", manifest_key="all-tabs-custom-format-4", keystroke="n"),
+    "all-tabs-custom-format-5": Shortcut(label="all tabs: custom format 5", manifest_key="all-tabs-custom-format-5", keystroke="o"),
+    "highlighted-tabs-custom-format-1": Shortcut(label="selected tabs: custom format 1", manifest_key="highlighted-tabs-custom-format-1", keystroke="p"),
+    "highlighted-tabs-custom-format-2": Shortcut(label="selected tabs: custom format 2", manifest_key="highlighted-tabs-custom-format-2", keystroke="q"),
+    "highlighted-tabs-custom-format-3": Shortcut(label="selected tabs: custom format 3", manifest_key="highlighted-tabs-custom-format-3", keystroke="r"),
+    # skipping s and t to avoid conflict with Firefox's menu shortcut
+    "highlighted-tabs-custom-format-4": Shortcut(label="selected tabs: custom format 4", manifest_key="highlighted-tabs-custom-format-4", keystroke="u"),
+    # skipping v to avoid conflict with Firefox's menu shortcut
+    "highlighted-tabs-custom-format-5": Shortcut(label="selected tabs: custom format 5", manifest_key="highlighted-tabs-custom-format-5", keystroke="w")
 }
 
 

--- a/e2e_test/keyboard_shortcuts.py
+++ b/e2e_test/keyboard_shortcuts.py
@@ -17,6 +17,9 @@ class Shortcut:
     def run_action_chain(self, actions: ActionChains):
         return actions.key_down(Keys.ALT).key_down(Keys.SHIFT).send_keys(self.keystroke).key_up(Keys.SHIFT).key_up(Keys.ALT)
 
+    def toFirefoxShortcut(self):
+        return "Alt+Shift+" + self.keystroke.upper()
+
 class KeyboardShortcuts:
     def __init__(self):
         self.items: list[Shortcut] = []

--- a/e2e_test/keyboard_shortcuts.py
+++ b/e2e_test/keyboard_shortcuts.py
@@ -1,5 +1,7 @@
 import pyautogui
 from dataclasses import dataclass
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
 
 @dataclass
 class Shortcut:
@@ -12,6 +14,8 @@ class Shortcut:
             with pyautogui.hold('alt'):
                 pyautogui.press(self.keystroke)
 
+    def run_action_chain(self, actions: ActionChains):
+        return actions.key_down(Keys.ALT).key_down(Keys.SHIFT).send_keys(self.keystroke).key_up(Keys.SHIFT).key_up(Keys.ALT)
 
 class KeyboardShortcuts:
     def __init__(self):


### PR DESCRIPTION
## Summary 

This pull request refactors the keyboard shortcut setup for Chrome and Firefox in the end-to-end tests. It introduces a more streamlined approach for handling shortcuts, improves compatibility with Firefox's API, and updates the shortcut key mappings to avoid conflicts with Firefox's reserved keys.

### Refactoring keyboard shortcut setup:

* [`e2e_test/conftest.py`](diffhunk://#diff-73eeed69f3c1a7ca07c057762e40a2c4ec476b59cea8053a3f4e5c82ac14cc00L223-R255): Refactored the Chrome shortcut setup to use the new `run_action_chain` method and updated the Firefox shortcut setup to leverage the `commands.update()` API for setting shortcuts. Removed redundant code for Firefox shortcut configuration.

### Enhancements to `Shortcut` class:

* [`e2e_test/keyboard_shortcuts.py`](diffhunk://#diff-ed91effdcb92b8efd36d63b4f09bc8e41776328db990fe4fe0f9b16b65f0376aR17-R21): Added `run_action_chain` method to create `ActionChains` for Chrome shortcuts and `toFirefoxShortcut` method to format shortcuts for Firefox. These methods improve code reuse and compatibility across browsers.

### Updated shortcut key mappings:

* [`e2e_test/keyboard_shortcuts.py`](diffhunk://#diff-ed91effdcb92b8efd36d63b4f09bc8e41776328db990fe4fe0f9b16b65f0376aL47-R74): Adjusted the shortcut key mappings to avoid conflicts with Firefox's reserved menu shortcuts. Skipped specific keys (e.g., `b`, `e`, `f`, etc.) to ensure smooth operation.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [x] Chrome stable (Windows)
- [x] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
