### PR TITLE
Refactor badge code as a  service object

### DIFF
--- a/src/services/badge-service.ts
+++ b/src/services/badge-service.ts
@@ -1,0 +1,136 @@
+/**
+ * Badge Service
+ *
+ * Handles browser extension badge (icon badge text and color) for visual feedback.
+ * Shows success/error states that auto-clear after a timeout.
+ */
+
+// Type Definitions
+type ColorArray = [number, number, number, number];
+type BadgeColor = string | ColorArray;
+
+// Constants
+const COLOR_GREEN = '#738a05';
+const COLOR_RED = '#d11b24';
+const COLOR_TRANSPARENT: ColorArray = [0, 0, 0, 0];
+
+const TEXT_OK = '✓';
+const TEXT_ERROR = '×';
+const TEXT_EMPTY = '';
+
+const FLASH_DURATION_MS = 3000;
+
+const ALARM_NAME_CLEAR_BADGE = 'clearBadge';
+
+export interface BadgeAPI {
+  setBadgeText: (details: { text: string }) => Promise<void>;
+  setBadgeBackgroundColor: (details: { color: BadgeColor }) => Promise<void>;
+}
+
+export interface AlarmsAPI {
+  create: (name: string, alarmInfo: { when: number }) => void;
+}
+
+/**
+ * Creates a badge service instance.
+ *
+ * @param badgeAPI - The browser badge API (browser.browserAction or chrome.action)
+ * @param alarmsAPI - The browser alarms API for scheduling badge clear
+ * @returns Badge service with methods to show success/error and clear badge
+ *
+ * @example
+ * ```typescript
+ * const badge = createBadgeService(
+ *   browser.browserAction || chrome.action,
+ *   browser.alarms
+ * );
+ *
+ * await badge.showSuccess();
+ * // Badge shows ✓ with green background, auto-clears after 3s
+ * ```
+ */
+export function createBadgeService(
+  badgeAPI: BadgeAPI,
+  alarmsAPI: AlarmsAPI,
+) {
+  return {
+    /**
+     * Shows success badge (✓ with green background).
+     * Badge will auto-clear after 3 seconds.
+     *
+     * Note: Calling this multiple times will reset the 3-second timer.
+     */
+    async showSuccess(): Promise<void> {
+      await Promise.all([
+        badgeAPI.setBadgeText({ text: TEXT_OK }),
+        badgeAPI.setBadgeBackgroundColor({ color: COLOR_GREEN }),
+      ]);
+      // Creating an alarm with the same name replaces any existing alarm
+      alarmsAPI.create(ALARM_NAME_CLEAR_BADGE, { when: Date.now() + FLASH_DURATION_MS });
+    },
+
+    /**
+     * Shows error badge (× with red background).
+     * Badge will auto-clear after 3 seconds.
+     *
+     * Note: Calling this multiple times will reset the 3-second timer.
+     */
+    async showError(): Promise<void> {
+      await Promise.all([
+        badgeAPI.setBadgeText({ text: TEXT_ERROR }),
+        badgeAPI.setBadgeBackgroundColor({ color: COLOR_RED }),
+      ]);
+      // Creating an alarm with the same name replaces any existing alarm
+      alarmsAPI.create(ALARM_NAME_CLEAR_BADGE, { when: Date.now() + FLASH_DURATION_MS });
+    },
+
+    /**
+     * Clears the badge (removes text and resets to transparent).
+     * This is automatically called after the flash duration expires.
+     */
+    async clear(): Promise<void> {
+      await Promise.all([
+        badgeAPI.setBadgeText({ text: TEXT_EMPTY }),
+        badgeAPI.setBadgeBackgroundColor({ color: COLOR_TRANSPARENT }),
+      ]);
+    },
+
+    /**
+     * Returns the alarm name used for clearing the badge.
+     * Use this to handle the alarm event in your alarm listener.
+     *
+     * @example
+     * ```typescript
+     * browser.alarms.onAlarm.addListener(async (alarm) => {
+     *   if (alarm.name === badge.getClearAlarmName()) {
+     *     await badge.clear();
+     *   }
+     * });
+     * ```
+     */
+    getClearAlarmName(): string {
+      return ALARM_NAME_CLEAR_BADGE;
+    },
+  };
+}
+
+export type BadgeService = ReturnType<typeof createBadgeService>;
+
+/**
+ * Creates a badge service using the browser's native APIs.
+ * Automatically detects whether to use browser.browserAction (Firefox MV2)
+ * or chrome.action (Chrome MV3).
+ *
+ * @example
+ * ```typescript
+ * const badge = createBrowserBadgeService();
+ * await badge.showSuccess();
+ * ```
+ */
+export function createBrowserBadgeService(): BadgeService {
+  const badgeAPI = (typeof browser !== 'undefined' && typeof browser.browserAction !== 'undefined')
+    ? browser.browserAction
+    : chrome.action;
+
+  return createBadgeService(badgeAPI, browser.alarms);
+}

--- a/test/services/badge-service.test.ts
+++ b/test/services/badge-service.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for badge service
+ */
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import { createBadgeService } from '../../src/services/badge-service.js';
+import type { AlarmsAPI, BadgeAPI } from '../../src/services/badge-service.js';
+
+describe('BadgeService', () => {
+  describe('showSuccess', () => {
+    it('should set success badge with green color and checkmark', async () => {
+      // Arrange
+      const mockBadgeAPI: BadgeAPI = {
+        setBadgeText: mock.fn(async () => { }),
+        setBadgeBackgroundColor: mock.fn(async () => { }),
+      };
+
+      const mockAlarmsAPI: AlarmsAPI = {
+        create: mock.fn(() => { }),
+      };
+
+      const badge = createBadgeService(mockBadgeAPI, mockAlarmsAPI);
+
+      // Act
+      await badge.showSuccess();
+
+      // Assert
+      assert.strictEqual(
+        (mockBadgeAPI.setBadgeText as any).mock.calls.length,
+        1,
+        'setBadgeText should be called once',
+      );
+      assert.deepStrictEqual(
+        (mockBadgeAPI.setBadgeText as any).mock.calls[0]?.arguments[0],
+        { text: '✓' },
+        'Badge text should be checkmark',
+      );
+
+      assert.strictEqual(
+        (mockBadgeAPI.setBadgeBackgroundColor as any).mock.calls.length,
+        1,
+        'setBadgeBackgroundColor should be called once',
+      );
+      assert.deepStrictEqual(
+        (mockBadgeAPI.setBadgeBackgroundColor as any).mock.calls[0]?.arguments[0],
+        { color: '#738a05' },
+        'Badge color should be green',
+      );
+    });
+
+    it('should schedule badge clear alarm', async () => {
+      // Arrange
+      const mockBadgeAPI: BadgeAPI = {
+        setBadgeText: mock.fn(async () => { }),
+        setBadgeBackgroundColor: mock.fn(async () => { }),
+      };
+
+      const mockAlarmsAPI: AlarmsAPI = {
+        create: mock.fn(() => { }),
+      };
+
+      const badge = createBadgeService(mockBadgeAPI, mockAlarmsAPI);
+      const beforeTime = Date.now();
+
+      // Act
+      await badge.showSuccess();
+
+      // Assert
+      assert.strictEqual(
+        (mockAlarmsAPI.create as any).mock.calls.length,
+        1,
+        'Alarm should be created',
+      );
+
+      const [alarmName, alarmInfo] = (mockAlarmsAPI.create as any).mock.calls[0]?.arguments;
+      assert.strictEqual(alarmName, 'clearBadge', 'Alarm name should be clearBadge');
+      assert.ok(
+        alarmInfo.when >= beforeTime + 3000,
+        'Alarm should be scheduled at least 3 seconds from now',
+      );
+      assert.ok(
+        alarmInfo.when <= Date.now() + 3100,
+        'Alarm should be scheduled within 3.1 seconds',
+      );
+    });
+  });
+
+  describe('showError', () => {
+    it('should set error badge with red color and X mark', async () => {
+      // Arrange
+      const mockBadgeAPI: BadgeAPI = {
+        setBadgeText: mock.fn(async () => { }),
+        setBadgeBackgroundColor: mock.fn(async () => { }),
+      };
+
+      const mockAlarmsAPI: AlarmsAPI = {
+        create: mock.fn(() => { }),
+      };
+
+      const badge = createBadgeService(mockBadgeAPI, mockAlarmsAPI);
+
+      // Act
+      await badge.showError();
+
+      // Assert
+      assert.strictEqual(
+        (mockBadgeAPI.setBadgeText as any).mock.calls.length,
+        1,
+        'setBadgeText should be called once',
+      );
+      assert.deepStrictEqual(
+        (mockBadgeAPI.setBadgeText as any).mock.calls[0]?.arguments[0],
+        { text: '×' },
+        'Badge text should be X mark',
+      );
+
+      assert.strictEqual(
+        (mockBadgeAPI.setBadgeBackgroundColor as any).mock.calls.length,
+        1,
+        'setBadgeBackgroundColor should be called once',
+      );
+      assert.deepStrictEqual(
+        (mockBadgeAPI.setBadgeBackgroundColor as any).mock.calls[0]?.arguments[0],
+        { color: '#d11b24' },
+        'Badge color should be red',
+      );
+    });
+
+    it('should schedule badge clear alarm', async () => {
+      // Arrange
+      const mockBadgeAPI: BadgeAPI = {
+        setBadgeText: mock.fn(async () => { }),
+        setBadgeBackgroundColor: mock.fn(async () => { }),
+      };
+
+      const mockAlarmsAPI: AlarmsAPI = {
+        create: mock.fn(() => { }),
+      };
+
+      const badge = createBadgeService(mockBadgeAPI, mockAlarmsAPI);
+
+      // Act
+      await badge.showError();
+
+      // Assert
+      assert.strictEqual(
+        (mockAlarmsAPI.create as any).mock.calls.length,
+        1,
+        'Alarm should be created',
+      );
+
+      const [alarmName] = (mockAlarmsAPI.create as any).mock.calls[0]?.arguments;
+      assert.strictEqual(alarmName, 'clearBadge', 'Alarm name should be clearBadge');
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear badge text and set transparent background', async () => {
+      // Arrange
+      const mockBadgeAPI: BadgeAPI = {
+        setBadgeText: mock.fn(async () => { }),
+        setBadgeBackgroundColor: mock.fn(async () => { }),
+      };
+
+      const mockAlarmsAPI: AlarmsAPI = {
+        create: mock.fn(() => { }),
+      };
+
+      const badge = createBadgeService(mockBadgeAPI, mockAlarmsAPI);
+
+      // Act
+      await badge.clear();
+
+      // Assert
+      assert.strictEqual(
+        (mockBadgeAPI.setBadgeText as any).mock.calls.length,
+        1,
+        'setBadgeText should be called once',
+      );
+      assert.deepStrictEqual(
+        (mockBadgeAPI.setBadgeText as any).mock.calls[0]?.arguments[0],
+        { text: '' },
+        'Badge text should be empty',
+      );
+
+      assert.strictEqual(
+        (mockBadgeAPI.setBadgeBackgroundColor as any).mock.calls.length,
+        1,
+        'setBadgeBackgroundColor should be called once',
+      );
+      assert.deepStrictEqual(
+        (mockBadgeAPI.setBadgeBackgroundColor as any).mock.calls[0]?.arguments[0],
+        { color: [0, 0, 0, 0] },
+        'Badge color should be transparent',
+      );
+    });
+
+    it('should not create any alarm', async () => {
+      // Arrange
+      const mockBadgeAPI: BadgeAPI = {
+        setBadgeText: mock.fn(async () => { }),
+        setBadgeBackgroundColor: mock.fn(async () => { }),
+      };
+
+      const mockAlarmsAPI: AlarmsAPI = {
+        create: mock.fn(() => { }),
+      };
+
+      const badge = createBadgeService(mockBadgeAPI, mockAlarmsAPI);
+
+      // Act
+      await badge.clear();
+
+      // Assert
+      assert.strictEqual(
+        (mockAlarmsAPI.create as any).mock.calls.length,
+        0,
+        'No alarm should be created',
+      );
+    });
+  });
+
+  describe('getClearAlarmName', () => {
+    it('should return the correct alarm name', () => {
+      // Arrange
+      const mockBadgeAPI: BadgeAPI = {
+        setBadgeText: mock.fn(async () => { }),
+        setBadgeBackgroundColor: mock.fn(async () => { }),
+      };
+
+      const mockAlarmsAPI: AlarmsAPI = {
+        create: mock.fn(() => { }),
+      };
+
+      const badge = createBadgeService(mockBadgeAPI, mockAlarmsAPI);
+
+      // Act
+      const alarmName = badge.getClearAlarmName();
+
+      // Assert
+      assert.strictEqual(alarmName, 'clearBadge', 'Alarm name should be clearBadge');
+    });
+  });
+
+  describe('Integration: success then clear', () => {
+    it('should show success badge and then clear it', async () => {
+      // Arrange
+      const mockBadgeAPI: BadgeAPI = {
+        setBadgeText: mock.fn(async () => { }),
+        setBadgeBackgroundColor: mock.fn(async () => { }),
+      };
+
+      const mockAlarmsAPI: AlarmsAPI = {
+        create: mock.fn(() => { }),
+      };
+
+      const badge = createBadgeService(mockBadgeAPI, mockAlarmsAPI);
+
+      // Act
+      await badge.showSuccess();
+      await badge.clear();
+
+      // Assert - success was shown
+      assert.deepStrictEqual(
+        (mockBadgeAPI.setBadgeText as any).mock.calls[0]?.arguments[0],
+        { text: '✓' },
+      );
+
+      // Assert - then cleared
+      assert.deepStrictEqual(
+        (mockBadgeAPI.setBadgeText as any).mock.calls[1]?.arguments[0],
+        { text: '' },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refactor the code related to badge as a service object so that it can be tested.

This patch is done by Claude Code.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
