### PR TITLE
Refactor menu creation as a service object

### DIFF
--- a/src/services/context-menu-service.ts
+++ b/src/services/context-menu-service.ts
@@ -1,0 +1,301 @@
+/**
+ * Context Menu Service
+ *
+ * Handles browser extension context menu (right-click menu) creation and management.
+ * Creates menus for copying links, images, selections, tabs, and bookmarks as Markdown.
+ */
+
+import type CustomFormat from '../lib/custom-format.js';
+
+// Type Definitions
+// Use native browser API types instead of custom definitions
+export interface ContextMenusAPI {
+  create: (createProperties: browser.menus._CreateCreateProperties) => void;
+  update: (id: string, updateProperties: browser.menus._UpdateUpdateProperties) => Promise<void>;
+  removeAll: () => Promise<void>;
+}
+
+export interface CustomFormatsProvider {
+  list: (context: 'single-link' | 'multiple-links') => Promise<CustomFormat[]>;
+}
+
+/**
+ * Creates a context menu service instance.
+ *
+ * @param contextMenusAPI - The browser context menus API
+ * @param customFormatsProvider - Provider for custom format templates
+ * @returns Context menu service with methods to create and refresh menus
+ *
+ * @example
+ * ```typescript
+ * const menuService = createContextMenuService(
+ *   browser.contextMenus,
+ *   CustomFormatsStorage
+ * );
+ *
+ * await menuService.createAll();
+ * ```
+ */
+export function createContextMenuService(
+  contextMenusAPI: ContextMenusAPI,
+  customFormatsProvider: CustomFormatsProvider,
+) {
+  /**
+   * Creates all context menus for the extension.
+   * This includes:
+   * - Page/Link menus (copy current page, copy link)
+   * - Image menu (copy image as Markdown)
+   * - Selection menu (copy selection as Markdown)
+   * - Tab menus (Firefox only - copy all/selected tabs)
+   * - Bookmark menu (Firefox only - copy bookmark/folder)
+   * - Custom format menus (user-defined templates)
+   */
+  async function createAll(): Promise<void> {
+    await contextMenusAPI.removeAll();
+
+    // Fetch custom formats
+    const singleLinkFormats = (await customFormatsProvider.list('single-link'))
+      .filter(format => format.showInMenus);
+
+    // Basic page and link menus
+    createBasicMenus(contextMenusAPI);
+
+    // Custom format menus for single links
+    createSingleLinkCustomFormatMenus(contextMenusAPI, singleLinkFormats);
+
+    // Image and selection menus
+    createImageAndSelectionMenus(contextMenusAPI);
+
+    // Firefox-specific: Tab and bookmark menus
+    await createFirefoxSpecificMenus(
+      contextMenusAPI,
+      customFormatsProvider,
+      singleLinkFormats,
+    );
+  }
+
+  return {
+    /**
+     * Creates all context menus for the extension.
+     * Removes all existing menus first to ensure clean state.
+     */
+    createAll,
+
+    /**
+     * Refreshes all context menus.
+     * Alias for createAll() - removes and recreates all menus.
+     */
+    async refresh(): Promise<void> {
+      await createAll();
+    },
+  };
+}
+
+export type ContextMenuService = ReturnType<typeof createContextMenuService>;
+
+/**
+ * Creates basic context menus for page and link.
+ */
+function createBasicMenus(contextMenusAPI: ContextMenusAPI): void {
+  contextMenusAPI.create({
+    id: 'current-tab',
+    title: 'Copy Page Link as Markdown',
+    type: 'normal',
+    contexts: ['page'],
+  });
+
+  contextMenusAPI.create({
+    id: 'link',
+    title: 'Copy Link as Markdown',
+    type: 'normal',
+    contexts: ['link'],
+  });
+}
+
+/**
+ * Creates custom format menus for single links.
+ */
+function createSingleLinkCustomFormatMenus(
+  contextMenusAPI: ContextMenusAPI,
+  formats: CustomFormat[],
+): void {
+  for (const format of formats) {
+    contextMenusAPI.create({
+      id: `current-tab-custom-format-${format.slot}`,
+      title: `Copy Page Link (${format.displayName})`,
+      contexts: ['page'],
+    });
+
+    contextMenusAPI.create({
+      id: `link-custom-format-${format.slot}`,
+      title: `Copy Link (${format.displayName})`,
+      contexts: ['link'],
+    });
+  }
+}
+
+/**
+ * Creates menus for images and text selection.
+ */
+function createImageAndSelectionMenus(contextMenusAPI: ContextMenusAPI): void {
+  contextMenusAPI.create({
+    id: 'image',
+    title: 'Copy Image as Markdown',
+    type: 'normal',
+    contexts: ['image'],
+  });
+
+  contextMenusAPI.create({
+    id: 'selection-as-markdown',
+    title: 'Copy Selection as Markdown',
+    type: 'normal',
+    contexts: ['selection'],
+  });
+}
+
+/**
+ * Creates Firefox-specific context menus (tabs and bookmarks).
+ * These features are only available in Firefox.
+ */
+async function createFirefoxSpecificMenus(
+  contextMenusAPI: ContextMenusAPI,
+  customFormatsProvider: CustomFormatsProvider,
+  singleLinkFormats: CustomFormat[],
+): Promise<void> {
+  try {
+    const multipleLinksFormats = (await customFormatsProvider.list('multiple-links'))
+      .filter(format => format.showInMenus);
+
+    // Update existing menus to also work on tabs
+    await contextMenusAPI.update('current-tab', {
+      contexts: ['page', 'tab'],
+    });
+
+    for (const format of singleLinkFormats) {
+      await contextMenusAPI.update(`current-tab-custom-format-${format.slot}`, {
+        contexts: ['page', 'tab'],
+      });
+    }
+
+    // Separator
+    contextMenusAPI.create({
+      id: 'separator-1',
+      type: 'separator',
+      contexts: ['tab'],
+    });
+
+    // All tabs menus
+    createAllTabsMenus(contextMenusAPI, multipleLinksFormats);
+
+    // Separator
+    contextMenusAPI.create({
+      id: 'separator-2',
+      type: 'separator',
+      contexts: ['tab'],
+    });
+
+    // Selected tabs menus
+    createSelectedTabsMenus(contextMenusAPI, multipleLinksFormats);
+
+    // Bookmark menu
+    createBookmarkMenu(contextMenusAPI);
+  } catch {
+    console.info('Firefox-specific context menus not supported in this browser');
+  }
+}
+
+/**
+ * Creates menus for copying all tabs in the current window.
+ */
+function createAllTabsMenus(
+  contextMenusAPI: ContextMenusAPI,
+  multipleLinksFormats: CustomFormat[],
+): void {
+  contextMenusAPI.create({
+    id: 'all-tabs-list',
+    title: 'Copy All Tabs',
+    type: 'normal',
+    contexts: ['tab'],
+  });
+
+  contextMenusAPI.create({
+    id: 'all-tabs-task-list',
+    title: 'Copy All Tabs (Task List)',
+    type: 'normal',
+    contexts: ['tab'],
+  });
+
+  for (const format of multipleLinksFormats) {
+    contextMenusAPI.create({
+      id: `all-tabs-custom-format-${format.slot}`,
+      title: `Copy All Tabs (${format.displayName})`,
+      type: 'normal',
+      contexts: ['tab'],
+    });
+  }
+}
+
+/**
+ * Creates menus for copying selected/highlighted tabs.
+ */
+function createSelectedTabsMenus(
+  contextMenusAPI: ContextMenusAPI,
+  multipleLinksFormats: CustomFormat[],
+): void {
+  contextMenusAPI.create({
+    id: 'highlighted-tabs-list',
+    title: 'Copy Selected Tabs',
+    type: 'normal',
+    contexts: ['tab'],
+  });
+
+  contextMenusAPI.create({
+    id: 'highlighted-tabs-task-list',
+    title: 'Copy Selected Tabs (Task List)',
+    type: 'normal',
+    contexts: ['tab'],
+  });
+
+  for (const format of multipleLinksFormats) {
+    contextMenusAPI.create({
+      id: `highlighted-tabs-custom-format-${format.slot}`,
+      title: `Copy Selected Tabs (${format.displayName})`,
+      type: 'normal',
+      visible: format.showInMenus,
+      contexts: ['tab'],
+    });
+  }
+}
+
+/**
+ * Creates menu for copying bookmarks (Firefox only).
+ */
+function createBookmarkMenu(contextMenusAPI: ContextMenusAPI): void {
+  try {
+    contextMenusAPI.create({
+      id: 'bookmark-link',
+      title: 'Copy Bookmark or Folder as Markdown',
+      type: 'normal',
+      contexts: ['bookmark'],
+    });
+  } catch {
+    console.info('Bookmark context menus not supported in this browser');
+  }
+}
+
+/**
+ * Creates a context menu service using the browser's native APIs.
+ *
+ * @param customFormatsProvider - Provider for custom format templates
+ * @example
+ * ```typescript
+ * import CustomFormatsStorage from './storage/custom-formats-storage.js';
+ * const menuService = createBrowserContextMenuService(CustomFormatsStorage);
+ * await menuService.createAll();
+ * ```
+ */
+export function createBrowserContextMenuService(
+  customFormatsProvider: CustomFormatsProvider,
+): ContextMenuService {
+  return createContextMenuService(browser.contextMenus, customFormatsProvider);
+}

--- a/test/services/context-menu-service.test.ts
+++ b/test/services/context-menu-service.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Unit tests for context menu service
+ */
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert';
+import { createContextMenuService } from '../../src/services/context-menu-service.js';
+import type {
+  ContextMenusAPI,
+  CustomFormatsProvider,
+} from '../../src/services/context-menu-service.js';
+
+// Mock CustomFormat class
+class MockCustomFormat {
+  slot: string;
+  name: string;
+  showInMenus: boolean;
+
+  constructor(slot: string, name: string, showInMenus: boolean = true) {
+    this.slot = slot;
+    this.name = name;
+    this.showInMenus = showInMenus;
+  }
+
+  get displayName(): string {
+    return this.name || `Custom Format ${this.slot}`;
+  }
+}
+
+describe('ContextMenuService', () => {
+  describe('createAll', () => {
+    it('should remove all existing menus first', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async () => []),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.createAll();
+
+      // Assert
+      assert.strictEqual(
+        (mockMenusAPI.removeAll as any).mock.calls.length,
+        1,
+        'removeAll should be called once',
+      );
+    });
+
+    it('should create basic menus (current-tab and link)', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async () => []),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.createAll();
+
+      // Assert
+      const createCalls = (mockMenusAPI.create as any).mock.calls;
+
+      // Find current-tab menu
+      const currentTabCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'current-tab',
+      );
+      assert.ok(currentTabCall, 'current-tab menu should be created');
+      assert.strictEqual(
+        currentTabCall.arguments[0]?.title,
+        'Copy Page Link as Markdown',
+      );
+      assert.deepStrictEqual(currentTabCall.arguments[0]?.contexts, ['page']);
+
+      // Find link menu
+      const linkCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'link',
+      );
+      assert.ok(linkCall, 'link menu should be created');
+      assert.strictEqual(linkCall.arguments[0]?.title, 'Copy Link as Markdown');
+      assert.deepStrictEqual(linkCall.arguments[0]?.contexts, ['link']);
+    });
+
+    it('should create image and selection menus', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async () => []),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.createAll();
+
+      // Assert
+      const createCalls = (mockMenusAPI.create as any).mock.calls;
+
+      // Find image menu
+      const imageCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'image',
+      );
+      assert.ok(imageCall, 'image menu should be created');
+      assert.strictEqual(imageCall.arguments[0]?.title, 'Copy Image as Markdown');
+
+      // Find selection menu
+      const selectionCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'selection-as-markdown',
+      );
+      assert.ok(selectionCall, 'selection menu should be created');
+      assert.strictEqual(
+        selectionCall.arguments[0]?.title,
+        'Copy Selection as Markdown',
+      );
+    });
+
+    it('should create custom format menus for single links', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const customFormat = new MockCustomFormat('1', 'My Custom Format');
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async (context) => {
+          if (context === 'single-link') {
+            return [customFormat as any];
+          }
+          return [];
+        }),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.createAll();
+
+      // Assert
+      const createCalls = (mockMenusAPI.create as any).mock.calls;
+
+      // Find custom format menu for current-tab
+      const customTabCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'current-tab-custom-format-1',
+      );
+      assert.ok(customTabCall, 'custom format menu for page should be created');
+      assert.strictEqual(
+        customTabCall.arguments[0]?.title,
+        'Copy Page Link (My Custom Format)',
+      );
+
+      // Find custom format menu for link
+      const customLinkCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'link-custom-format-1',
+      );
+      assert.ok(customLinkCall, 'custom format menu for link should be created');
+      assert.strictEqual(
+        customLinkCall.arguments[0]?.title,
+        'Copy Link (My Custom Format)',
+      );
+    });
+
+    it('should not create menus for custom formats with showInMenus=false', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const hiddenFormat = new MockCustomFormat('1', 'Hidden Format', false);
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async (context) => {
+          if (context === 'single-link') {
+            return [hiddenFormat as any];
+          }
+          return [];
+        }),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.createAll();
+
+      // Assert
+      const createCalls = (mockMenusAPI.create as any).mock.calls;
+
+      // Should not find custom format menu
+      const customTabCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'current-tab-custom-format-1',
+      );
+      assert.strictEqual(
+        customTabCall,
+        undefined,
+        'custom format with showInMenus=false should not be created',
+      );
+    });
+
+    it('should attempt to create Firefox-specific menus', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async () => []),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.createAll();
+
+      // Assert - should attempt to update current-tab menu for 'tab' context
+      const updateCalls = (mockMenusAPI.update as any).mock.calls;
+      const updateCurrentTabCall = updateCalls.find(
+        (call: any) => call.arguments[0] === 'current-tab',
+      );
+
+      assert.ok(
+        updateCurrentTabCall,
+        'should attempt to update current-tab menu for tab context',
+      );
+      assert.deepStrictEqual(
+        updateCurrentTabCall.arguments[1]?.contexts,
+        ['page', 'tab'],
+      );
+    });
+
+    it('should create all tabs menus when Firefox features are supported', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async () => []),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.createAll();
+
+      // Assert
+      const createCalls = (mockMenusAPI.create as any).mock.calls;
+
+      // Should create all-tabs menus
+      const allTabsCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'all-tabs-list',
+      );
+      assert.ok(allTabsCall, 'all-tabs-list menu should be created');
+
+      const allTabsTaskCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'all-tabs-task-list',
+      );
+      assert.ok(allTabsTaskCall, 'all-tabs-task-list menu should be created');
+
+      // Should create highlighted tabs menus
+      const highlightedCall = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'highlighted-tabs-list',
+      );
+      assert.ok(highlightedCall, 'highlighted-tabs-list menu should be created');
+    });
+  });
+
+  describe('refresh', () => {
+    it('should be an alias for createAll', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async () => []),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.refresh();
+
+      // Assert
+      assert.strictEqual(
+        (mockMenusAPI.removeAll as any).mock.calls.length,
+        1,
+        'removeAll should be called',
+      );
+      assert.ok(
+        (mockMenusAPI.create as any).mock.calls.length > 0,
+        'create should be called',
+      );
+    });
+  });
+
+  describe('Integration: with custom formats', () => {
+    it('should create menus for both single and multiple link formats', async () => {
+      // Arrange
+      const mockMenusAPI: ContextMenusAPI = {
+        create: mock.fn(() => {}),
+        update: mock.fn(async () => {}),
+        removeAll: mock.fn(async () => {}),
+      };
+
+      const singleFormat = new MockCustomFormat('1', 'Single Format');
+      const multipleFormat = new MockCustomFormat('2', 'Multiple Format');
+
+      const mockFormatsProvider: CustomFormatsProvider = {
+        list: mock.fn(async (context) => {
+          if (context === 'single-link') {
+            return [singleFormat as any];
+          }
+          if (context === 'multiple-links') {
+            return [multipleFormat as any];
+          }
+          return [];
+        }),
+      };
+
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider);
+
+      // Act
+      await service.createAll();
+
+      // Assert
+      const createCalls = (mockMenusAPI.create as any).mock.calls;
+
+      // Should have single link custom format menus
+      const singleLinkMenu = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'current-tab-custom-format-1',
+      );
+      assert.ok(singleLinkMenu, 'single link custom format menu should be created');
+
+      // Should have multiple links custom format menus
+      const allTabsCustomMenu = createCalls.find(
+        (call: any) => call.arguments[0]?.id === 'all-tabs-custom-format-2',
+      );
+      assert.ok(
+        allTabsCustomMenu,
+        'all-tabs custom format menu should be created',
+      );
+    });
+  });
+});


### PR DESCRIPTION

## Summary

Refactor menu creation as a service object so that it can be tested.

This patch is done by Claude Code

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
