### PR TITLE
Improve repo's code security by fixing existing code scanning alerts

### DIFF
--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -440,11 +440,11 @@ class FixtureServer:
         
         # Find an available port
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(('', 0))
+            s.bind(('127.0.0.1', 0))
             self.port = s.getsockname()[1]
         
         # Create and start the server in a separate thread
-        self.server = http.server.HTTPServer(("", self.port), 
+        self.server = http.server.HTTPServer(("127.0.0.1", self.port), 
             lambda *args: http.server.SimpleHTTPRequestHandler(*args, directory=fixtures_dir))
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True

--- a/src/iframe-copy.ts
+++ b/src/iframe-copy.ts
@@ -28,7 +28,7 @@ window.addEventListener('message', (event: MessageEvent<CopyMessage>) => {
       }
 
       const textBox = document.getElementById('copy') as HTMLTextAreaElement;
-      textBox.innerHTML = text;
+      textBox.value = text;
       textBox.select();
       const result = document.execCommand('Copy');
       if (result) {
@@ -42,7 +42,7 @@ window.addEventListener('message', (event: MessageEvent<CopyMessage>) => {
           options,
         );
       }
-      textBox.innerHTML = '';
+      textBox.value = '';
       break;
     }
 

--- a/test/services/link-export-service.test.ts
+++ b/test/services/link-export-service.test.ts
@@ -21,7 +21,7 @@ import type {
 
 // Simple mock markdown formatter for tests
 const mockMarkdown: MarkdownFormatter = {
-  escapeLinkText: (text: string) => text.replace(/\[/g, '\\[').replace(/\]/g, '\\]'),
+  escapeLinkText: (text: string) => text.replace(/\\/g, '\\\\').replace(/\[/g, '\\[').replace(/\]/g, '\\]'),
   linkTo: (title: string, url: string) => `[${title}](${url})`,
   list: vi.fn().mockImplementation(() => {
     throw new Error('list() should not be called in link export tests');
@@ -82,7 +82,7 @@ describe('link Export Service - Pure Functions', () => {
         'Test [Link]',
         'https://example.com',
         '1',
-        text => text.replace(/\[/g, '\\[').replace(/\]/g, '\\]'),
+        text => text.replace(/\\/g, '\\\\').replace(/\[/g, '\\[').replace(/\]/g, '\\]'),
         mockProvider,
       );
 
@@ -108,7 +108,7 @@ describe('link Export Service - Pure Functions', () => {
         '[Special]',
         'https://example.com',
         '1',
-        text => text.replace(/\[/g, '\\[').replace(/\]/g, '\\]'),
+        text => text.replace(/\\/g, '\\\\').replace(/\[/g, '\\[').replace(/\]/g, '\\]'),
         mockProvider,
       );
 

--- a/test/services/tab-export-service.test.ts
+++ b/test/services/tab-export-service.test.ts
@@ -106,7 +106,7 @@ describe('tab Export Service - Refactored (Pure Functions)', () => {
 
       const tabs = convertBrowserTabsToTabs(
         browserTabs,
-        text => text.replace('[', '\\[').replace(']', '\\]'),
+        text => text.replace(/\\/g, '\\\\').replace(/\[/g, '\\[').replace(/\]/g, '\\]'),
       );
 
       expect(tabs[0]?.title).toBe('\\[Special\\]');


### PR DESCRIPTION
## Summary

This PR combines fixes from a number of draft PRs in the [kilasuit/copy-as-markdown](https://github.com/kilasuit/copy-as-markdown) repo that were created as part of attempting to fix the code scanning alerts that GitHub had raised once code scanning was set up as per this image.

<img width="1667" height="880" alt="image" src="https://github.com/user-attachments/assets/505d6615-a45f-4e21-b711-7dcf7401f638" />

For more information on code scanning [please refer to the docs.](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning)

## Context

This PR improves the security posture of this repository by implementing a few small but recommended changes as discovered with code scanning.

- Bind socket to 127.0.0.1 instead of all interfaces
- Use textBox.value instead of innerHTML to prevent XSS
- Fix incomplete string escaping in test/services/link-export-service.test.ts
- Fix incomplete string escaping in test/services/tab-export-service.test.ts

All escaping functions now properly escape backslashes first using global regex before escaping brackets.

## Notes

This PR and the time used in creating it was as part of a small test experiment into usefulness in using the code scanning tooling that GitHub makes available and how this could be combined with various GitHub Copilot features to simplify and quicken the time used for discovering and implementing any potential required fixes in the most optimal way

This PR is the result of combining the below mentioned 10 draft PR's for each of the code scanning alerts that were raised into a [single PR](https://github.com/kilasuit/copy-as-markdown/pull/12) by ways of performing a further review that led to an improved fix that should cover the requirements of the majority of fixes required in a smaller amount of changed code to achieve the same desired results

As such the information contained in the above linked single PR and the information in all the draft pr's below should provide enough background information for this PR.

### Draft PR's
https://github.com/kilasuit/copy-as-markdown/pull/1
https://github.com/kilasuit/copy-as-markdown/pull/2
https://github.com/kilasuit/copy-as-markdown/pull/3
https://github.com/kilasuit/copy-as-markdown/pull/4
https://github.com/kilasuit/copy-as-markdown/pull/5
https://github.com/kilasuit/copy-as-markdown/pull/6
https://github.com/kilasuit/copy-as-markdown/pull/7
https://github.com/kilasuit/copy-as-markdown/pull/8
https://github.com/kilasuit/copy-as-markdown/pull/9
https://github.com/kilasuit/copy-as-markdown/pull/10


## Tests

- I have not verified whether or not if these changes have had any negative impact.
- I also don't currently have the time to be able to spend on testing these changes across the below test matrix.
- As such this PR is raised as is, for reference, and is up to the maintainer @yorkxin if they want to accept this PR as is, or take the work as part of this PR and expand on it further, including running any required tests.

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
