### PR TITLE
Fix: tabGroups API is not refreshed when granted/revoked permission

### DIFF
--- a/src/services/browser-tab-data-fetcher.ts
+++ b/src/services/browser-tab-data-fetcher.ts
@@ -7,7 +7,7 @@ interface TabDataFetcherDeps {
   tabs: TabsAPI;
   windows: WindowsAPI;
   runtime: RuntimeAPI;
-  tabGroups?: TabGroupsAPI;
+  tabGroups: () => TabGroupsAPI | undefined;
 }
 
 export class BrowserTabDataFetcher implements TabDataFetcher {
@@ -38,7 +38,7 @@ export class BrowserTabDataFetcher implements TabDataFetcher {
   }
 
   async fetchTabGroups(windowId: number): Promise<chrome.tabGroups.TabGroup[]> {
-    const tabGroupsAPI = this.deps.tabGroups;
+    const tabGroupsAPI = this.deps.tabGroups();
     if (!tabGroupsAPI) {
       return [];
     }
@@ -65,16 +65,13 @@ export class BrowserTabDataFetcher implements TabDataFetcher {
  * Default browser-backed data fetcher factory.
  */
 export function createBrowserTabDataFetcher(): BrowserTabDataFetcher {
-  // TODO: Review this, do we need permission checking or not?
-  const tabGroupsAPI = (typeof chrome !== 'undefined' && chrome.tabGroups)
-    ? chrome.tabGroups as TabGroupsAPI
-    : undefined;
-
   return new BrowserTabDataFetcher({
     permissions: browser.permissions,
     tabs: browser.tabs,
     windows: browser.windows,
     runtime: browser.runtime,
-    tabGroups: tabGroupsAPI,
+    tabGroups: () => (typeof chrome !== 'undefined' && chrome.tabGroups)
+      ? chrome.tabGroups as TabGroupsAPI
+      : undefined,
   });
 }

--- a/test/services/browser-tab-data-fetcher.test.ts
+++ b/test/services/browser-tab-data-fetcher.test.ts
@@ -33,11 +33,38 @@ describe('browserTabDataFetcher', () => {
       tabs: { query: vi.fn() },
       windows: { create: vi.fn() },
       runtime: { getURL: vi.fn() },
-      tabGroups: { query: tabGroupsQuery },
+      tabGroups: () => ({ query: tabGroupsQuery }),
     });
 
     const result = await fetcher.fetchTabGroups(5);
     expect(result).toEqual([{ id: 1 }]);
     expect(tabGroupsQuery).toHaveBeenCalledWith({ windowId: 5 });
+  });
+
+  it('re-checks tabGroups API availability on each call', async () => {
+    const permissionsContains = vi.fn(async () => true);
+    const tabGroupsQuery = vi.fn(async () => [{ id: 2 } as chrome.tabGroups.TabGroup]);
+    const tabGroupsProvider = vi.fn()
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue({ query: tabGroupsQuery });
+
+    const fetcher = new BrowserTabDataFetcher({
+      permissions: { contains: permissionsContains },
+      tabs: { query: vi.fn() },
+      windows: { create: vi.fn() },
+      runtime: { getURL: vi.fn() },
+      tabGroups: tabGroupsProvider,
+    });
+
+    const firstResult = await fetcher.fetchTabGroups(3);
+    expect(firstResult).toEqual([]);
+    expect(tabGroupsProvider).toHaveBeenCalledTimes(1);
+    expect(permissionsContains).not.toHaveBeenCalled();
+
+    const secondResult = await fetcher.fetchTabGroups(3);
+    expect(secondResult).toEqual([{ id: 2 }]);
+    expect(tabGroupsProvider).toHaveBeenCalledTimes(2);
+    expect(permissionsContains).toHaveBeenCalledTimes(1);
+    expect(tabGroupsQuery).toHaveBeenCalledWith({ windowId: 3 });
   });
 });


### PR DESCRIPTION
Evaluate tabGroups API availability each time when it's used. Previously, service object caches the reference it received during initialization, which prevents API becomes available when user granted permission; and vice versa.