### PR TITLE
add URL decoding for Unicode characters

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -85,6 +85,7 @@ async function refreshMarkdownInstance(): Promise<void> {
   markdownInstance.alwaysEscapeLinkBracket = settings.alwaysEscapeLinkBrackets;
   markdownInstance.unorderedListStyle = settings.styleOfUnorderedList;
   markdownInstance.indentationStyle = settings.styleOfTabGroupIndentation;
+  markdownInstance.decodeURLs = settings.decodeURLs;
 }
 
 browser.alarms.onAlarm.addListener(async (alarm) => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -5,11 +5,13 @@ const SKLinkTextAlwaysEscapeBrackets = 'linkTextAlwaysEscapeBrackets';
 // [sic.] The following keys have spaces at the end since they were introduced (typo). Do not modify.
 const SKStyleOfUnorderedList = 'styleOfUnorderedList ';
 const SKStyleTabGroupIndentation = 'style.tabgroup.indentation ';
+const SKDecodeURLs = 'decodeURLs';
 
 interface Settings {
   alwaysEscapeLinkBrackets: boolean;
   styleOfUnorderedList: UnorderedListStyle;
   styleOfTabGroupIndentation: TabGroupIndentationStyle;
+  decodeURLs: boolean;
 }
 
 /**
@@ -25,6 +27,7 @@ export default {
       [SKLinkTextAlwaysEscapeBrackets]: false,
       [SKStyleOfUnorderedList]: UnorderedListStyle.Dash,
       [SKStyleTabGroupIndentation]: TabGroupIndentationStyle.Spaces,
+      [SKDecodeURLs]: false,
     };
   },
 
@@ -50,6 +53,12 @@ export default {
     });
   },
 
+  async setDecodeURLs(value: boolean): Promise<void> {
+    await browser.storage.sync.set({
+      [SKDecodeURLs]: value,
+    });
+  },
+
   async reset(): Promise<void> {
     await browser.storage.sync.remove(this.keys);
   },
@@ -61,6 +70,7 @@ export default {
       alwaysEscapeLinkBrackets: all[SKLinkTextAlwaysEscapeBrackets] as boolean,
       styleOfUnorderedList: all[SKStyleOfUnorderedList] as UnorderedListStyle,
       styleOfTabGroupIndentation: all[SKStyleTabGroupIndentation] as TabGroupIndentationStyle,
+      decodeURLs: all[SKDecodeURLs] as boolean,
     };
   },
 };

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -109,6 +109,21 @@
             so that Copy as Markdown always escape brackets in the link text.
           </p>
         </form>
+
+        <form id="form-decode-urls" class="field">
+          <label class="label">URL Decoding</label>
+          <div class="control">
+            <label class="checkbox">
+              <input type="checkbox" name="enabled"/>
+              Decode URL-encoded Unicode characters
+            </label>
+          </div>
+          <p class="help">
+            When enabled, URL-encoded Unicode characters (like <code>%E4%B8%AD%E6%96%87</code>)
+            will be decoded to their original characters (like <code>中文</code>) in markdown links.
+            This makes URLs more readable but may break compatibility with some markdown processors.
+          </p>
+        </form>
       </div>
       <div class="field is-grouped">
         <div class="control">

--- a/src/ui/options.ts
+++ b/src/ui/options.ts
@@ -29,6 +29,7 @@ async function loadSettings(): Promise<void> {
     const formEscapeBrackets = document.forms.namedItem('form-link-text-always-escape-brackets');
     const formUnorderedList = document.forms.namedItem('form-style-of-unordered-list');
     const formTabGroupIndentation = document.forms.namedItem('form-style-of-tab-group-indentation');
+    const formDecodeURLs = document.forms.namedItem('form-decode-urls');
 
     if (formEscapeBrackets) {
       const checkbox = formEscapeBrackets.elements.namedItem('enabled') as HTMLInputElement | null;
@@ -41,6 +42,10 @@ async function loadSettings(): Promise<void> {
     if (formTabGroupIndentation) {
       const indentation = formTabGroupIndentation.elements.namedItem('indentation') as RadioNodeList | null;
       if (indentation) indentation.value = settings.styleOfTabGroupIndentation;
+    }
+    if (formDecodeURLs) {
+      const checkbox = formDecodeURLs.elements.namedItem('enabled') as HTMLInputElement | null;
+      if (checkbox) checkbox.checked = settings.decodeURLs;
     }
     hideFlash();
   } catch (error) {
@@ -90,6 +95,20 @@ if (formUnorderedList) {
     try {
       const target = event.target as HTMLInputElement;
       await Settings.setStyleOfUnrderedList(target.value as UnorderedListStyle);
+      hideFlash();
+    } catch (error) {
+      console.error('failed to save settings:', error);
+      showFlash('Failed to save setting. Please try again.');
+    }
+  });
+}
+
+const formDecodeURLs = document.forms.namedItem('form-decode-urls');
+if (formDecodeURLs) {
+  formDecodeURLs.addEventListener('change', async (event) => {
+    try {
+      const target = event.target as HTMLInputElement;
+      await Settings.setDecodeURLs(target.checked);
       hideFlash();
     } catch (error) {
       console.error('failed to save settings:', error);

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -99,4 +99,59 @@ describe('markdown', () => {
       });
     });
   });
+
+  describe('linkTo() with URL decoding', () => {
+    describe('decodeURLs=false (default)', () => {
+      const markdown = new Markdown({ decodeURLs: false });
+
+      it('preserves encoded URLs', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/%E4%B8%AD%E6%96%87'))
+          .toBe('[Test](https://example.com/%E4%B8%AD%E6%96%87)');
+      });
+
+      it('preserves already decoded URLs', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/中文'))
+          .toBe('[Test](https://example.com/中文)');
+      });
+    });
+
+    describe('decodeURLs=true', () => {
+      const markdown = new Markdown({ decodeURLs: true });
+
+      it('decodes URL-encoded Unicode characters', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/%E4%B8%AD%E6%96%87'))
+          .toBe('[Test](https://example.com/中文)');
+      });
+
+      it('keeps spaces encoded for markdown compatibility', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/hello%20world'))
+          .toBe('[Test](https://example.com/hello%20world)'); // Space remains %20
+      });
+
+      it('keeps parentheses encoded for markdown compatibility', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/page%28with%29parens'))
+          .toBe('[Test](https://example.com/page%28with%29parens)'); // Parentheses remain encoded
+      });
+
+      it('decodes query parameters', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/search?q=%E4%B8%AD%E6%96%87'))
+          .toBe('[Test](https://example.com/search?q=中文)');
+      });
+
+      it('passes through already decoded URLs', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/中文'))
+          .toBe('[Test](https://example.com/中文)');
+      });
+
+      it('falls back to original URL on malformed encoding', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/%ZZ'))
+          .toBe('[Test](https://example.com/%ZZ)');
+      });
+
+      it('handles mixed encoded/decoded URLs', () => {
+        expect(markdown.linkTo('Test', 'https://example.com/%E4%B8%AD%E6%96%87/decoded'))
+          .toBe('[Test](https://example.com/中文/decoded)');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add an option to decode URL-encoded Unicode characters in markdown links. When enabled, copy URLs by clicking the icon like `https://github.com/yorkxin/copy-as-markdown?%E4%B8%AD%E6%96%87` will be copied as `https://github.com/yorkxin/copy-as-markdown?中文`.

- Add decodeURLs setting to decode URL-encoded Unicode in markdown links
- Implement decodeURI() with fallback for malformed URLs
- Keep spaces and parentheses encoded for markdown compatibility
- Add options page UI control with helpful documentation
- Include comprehensive test coverage for edge cases

The option to enable decode URL. It is disabled by default for backward compatibility
<img width="1740" height="1365" alt="image" src="https://github.com/user-attachments/assets/23f721b5-0299-484c-9522-2b02d904acea" />

Then click the md icon to get the URL-decoded 
<img width="2025" height="570" alt="image" src="https://github.com/user-attachments/assets/23e7eabf-69ea-4820-b392-771116ac669a" />




## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [x] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)
