### PR TITLE
Fix list paragraph conversion for Turndown selections

### DIFF
--- a/test/fixtures/chatgpt-list.html
+++ b/test/fixtures/chatgpt-list.html
@@ -1,0 +1,31 @@
+<ul data-start="1687" data-end="1907">
+  <li data-start="1687" data-end="1721">
+    <p data-start="1689" data-end="1721">
+      <strong data-start="1689" data-end="1703">For coding</strong> →
+      <em data-start="1706" data-end="1721">IBM Plex Mono</em>
+    </p>
+  </li>
+  <li data-start="1722" data-end="1783">
+    <p data-start="1724" data-end="1783">
+      <strong data-start="1724" data-end="1754"
+        >For documents / retro feel</strong
+      >
+      → <em data-start="1757" data-end="1783">Courier / CMU Typewriter</em>
+    </p>
+  </li>
+  <li data-start="1784" data-end="1842">
+    <p data-start="1786" data-end="1842">
+      <strong data-start="1786" data-end="1818"
+        >For LaTeX / academic writing</strong
+      >
+      → <em data-start="1821" data-end="1842">CMU Typewriter Text</em>
+    </p>
+  </li>
+  <li data-start="1843" data-end="1907">
+    <p data-start="1845" data-end="1907">
+      <strong data-start="1845" data-end="1871">For design experiments</strong>
+      →
+      <em data-start="1874" data-end="1907">American Typewriter (mono cuts)</em>
+    </p>
+  </li>
+</ul>

--- a/test/ui/selection-list-paragraph.spec.ts
+++ b/test/ui/selection-list-paragraph.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { selectionToMarkdown } from '../../src/content-scripts/selection-to-markdown.js';
+
+async function convertSelectionToMarkdown(html: string): Promise<string> {
+  document.body.innerHTML = html;
+  const selection = window.getSelection();
+  const range = document.createRange();
+  range.selectNodeContents(document.body);
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  try {
+    return await selectionToMarkdown(
+      '/src/vendor/turndown.mjs',
+      '/src/vendor/turndown-plugin-gfm.mjs',
+      {
+        headingStyle: 'atx',
+        bulletListMarker: '-',
+      },
+    );
+  } finally {
+    selection?.removeAllRanges();
+    document.body.innerHTML = '';
+  }
+}
+
+describe('selectionToMarkdown list-item paragraph handling', () => {
+  it('fixes fixture: no indented blank lines between bullet items', async () => {
+    const html = await fetch('/test/fixtures/chatgpt-list.html').then(r => r.text());
+    const md = await convertSelectionToMarkdown(html);
+
+    expect(md).toBe(
+      '-   **For coding** → _IBM Plex Mono_\n'
+      + '-   **For documents / retro feel** → _Courier / CMU Typewriter_\n'
+      + '-   **For LaTeX / academic writing** → _CMU Typewriter Text_\n'
+      + '-   **For design experiments** → _American Typewriter (mono cuts)_',
+    );
+    expect(md).not.toContain('\n    \n-');
+  });
+
+  it('keeps loose list formatting for multi-paragraph list items', async () => {
+    const html = '<ul><li><p>a</p><p>b</p></li></ul>';
+    const md = await convertSelectionToMarkdown(html);
+
+    expect(md).toBe('-   a\n    \n    b');
+  });
+
+  it('keeps spacing before nested list when paragraph is not only child', async () => {
+    const html = '<ul><li><p>a</p><ul><li>b</li></ul></li></ul>';
+    const md = await convertSelectionToMarkdown(html);
+
+    expect(md).toBe('-   a\n    \n    -   b');
+  });
+
+  it('does not affect list items without p wrappers', async () => {
+    const html = '<ul><li>a</li><li><strong>b</strong></li></ul>';
+    const md = await convertSelectionToMarkdown(html);
+
+    expect(md).toBe('-   a\n-   **b**');
+  });
+
+  it('applies to ordered list items', async () => {
+    const html = '<ol><li><p>one</p></li><li><p>two</p></li></ol>';
+    const md = await convertSelectionToMarkdown(html);
+
+    expect(md).toBe('1.  one\n2.  two');
+  });
+
+  it('does not affect paragraphs outside list items', async () => {
+    const html = '<p>outside</p><ul><li><p>inside</p></li></ul>';
+    const md = await convertSelectionToMarkdown(html);
+
+    expect(md).toBe('outside\n\n-   inside');
+  });
+
+  it('handles empty paragraph list items without breaking following items', async () => {
+    const html = '<ul><li><p></p></li><li><p>x</p></li></ul>';
+    const md = await convertSelectionToMarkdown(html);
+
+    expect(md).toBe('-   x');
+  });
+});


### PR DESCRIPTION
## Summary

Add a targeted Turndown rule for single-paragraph list items to avoid indented blank lines between bullets, and add fixture-driven browser tests covering edge cases.

This is useful for websites that wrap the content of list item in a single paragraph, found on some popular websites such as ChatGPT.

Original issue: #212 

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)

---

## AI Disclosure

- [x] I used coding agents to create this patch. I understand and am responsible for all the code it generates.