### PR TITLE
chore: ignore .zed directory in eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ export default antfu({
     'dist/**',
     'build/**',
     'activate', // python libraries
+    '.zed/**',
   ],
 
   // Rule overrides


### PR DESCRIPTION
## Summary

Zed settings are controlled by Zed and should not be subject to ESlint.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)


## AI Disclosure

<!-- Check one. Be responsible. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [x] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [ ] I did not use any coding agent to create this patch. I am reponsible for all the code I wrote.
