### PR TITLE
Fix extra separator at the top of the tab context menu (Firefox)

### DIFF
--- a/src/services/context-menu-service.ts
+++ b/src/services/context-menu-service.ts
@@ -89,6 +89,13 @@ export function createContextMenuService(
       menus = menus.concat(createBookmarkMenu());
     }
 
+    // the only potential separator is assigned to the `tab` context so check if the separator is at the first item
+    const i = menus.findIndex(menu => (menu.contexts || []).includes('tab'));
+    if (i !== -1 && menus[i]!.type === 'separator') {
+      // drop the element at i
+      menus = menus.slice(0, i).concat(menus.slice(i + 1, menus.length));
+    }
+
     menus.forEach(menu => contextMenusAPI.create(menu));
   }
 
@@ -207,7 +214,7 @@ function createFirefoxSpecificMenus(
 
   if (shouldShowAnyTabSection) {
     menus = menus.concat({
-      id: 'separator-1',
+      id: 'separator-tab-1',
       type: 'separator',
       contexts: ['tab'],
     });
@@ -220,7 +227,7 @@ function createFirefoxSpecificMenus(
 
   if (shouldShowAnyTabSection) {
     menus = menus.concat({
-      id: 'separator-2',
+      id: 'separator-tab-2',
       type: 'separator',
       contexts: ['tab'],
     });

--- a/test/services/context-menu-service.test.ts
+++ b/test/services/context-menu-service.test.ts
@@ -337,6 +337,46 @@ describe('contextMenuService', () => {
       expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'highlighted-tabs-title-as-list' }));
       expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'highlighted-tabs-url-as-list' }));
     });
+
+    it('should not include a separator as the first item in "tab" context', async () => {
+      const calls: browser.menus._CreateCreateProperties[] = [];
+      const createMock = vi.fn((args: browser.menus._CreateCreateProperties) => {
+        calls.push(args);
+      });
+      const removeMock = vi.fn(async () => { });
+      const removeAllMock = vi.fn(async () => { });
+
+      const mockMenusAPI: ContextMenusAPI = {
+        create: createMock,
+        remove: removeMock,
+        removeAll: removeAllMock,
+      };
+
+      const mockFormatsProvider: CustomFormatsListProvider = {
+        list: vi.fn(async () => []),
+      };
+
+      const builtIns = makeBuiltInProvider({
+        singleLink: false,
+        tabLinkList: true,
+        tabTaskList: false,
+        tabTitleList: false,
+        tabUrlList: false,
+      });
+      const service = createContextMenuService(mockMenusAPI, mockFormatsProvider, builtIns);
+
+      await service.createAll();
+
+      expect(createMock).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'separator-tab-1' }));
+      expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'separator-tab-2' }));
+
+      expect(calls.filter(call => call.contexts?.includes('tab'))).toEqual([
+        expect.objectContaining({ id: 'tmp-tab', contexts: ['tab'] }),
+        expect.objectContaining({ id: 'all-tabs-link-as-list', type: 'normal', contexts: ['tab'] }),
+        expect.objectContaining({ id: 'separator-tab-2', type: 'separator', contexts: ['tab'] }),
+        expect.objectContaining({ id: 'highlighted-tabs-link-as-list', type: 'normal', contexts: ['tab'] }),
+      ]);
+    });
   });
 
   describe('refresh', () => {


### PR DESCRIPTION
## Summary

On Firefox, context menus also appear on the tab bar

When the context menus are configured as follows, there will be an extra spearator at the top of the context menu:

- Multiple Links:
  - Select one or many
- Single Link
  - Unselect all

This patch fixes the issue by removing the extra separator if it is the first item applied to `tab` context.

Note that this is only reproducible on KDE Desktop and Windows 10. On macOS it seems that the extra separator at the top do not appear.

Note that this is not a future-proof fix, because the context menus are designed to have a single ID that can be applied to multiple contexts (no context, page, link, tab etc) so if the separator is added to other contexts, the bug will appear again. 

Fixes #221 

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [x] Chrome stable (Windows)
- [x] Firefox stable (Windows)
- [x] Chrome stable (KDE)
- [x] Firefox stable (KDE)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)


## AI Disclosure

<!-- Check one. Be honest. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [ ] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [x] I did not use any coding agent to create this patch. I am responsible for all the code I wrote.
