### PR TITLE
Fix selection-as-markdown clipboard fallback on noisy pages

### DIFF
--- a/fixtures/selection-noisy.html
+++ b/fixtures/selection-noisy.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Selection With Message Noise</title>
+</head>
+<body>
+  <main id="content">
+    <h2>Specs and Compatibility</h2>
+    <p>Technical Specifications</p>
+
+    <h5>Headphone</h5>
+    <ul>
+      <li><strong>Driver:</strong> 1.57 in(40mm) Biocellulose</li>
+      <li><strong>Weight:</strong> 10.22 oz(290 g)</li>
+    </ul>
+
+    <h5>Battery &amp; Charging</h5>
+    <ul>
+      <li><strong>Battery type:</strong> rechargeable</li>
+      <li><strong>No lighting:</strong> up to 90 hrs</li>
+    </ul>
+  </main>
+
+  <script>
+    window.addEventListener('copy', (event) => {
+      const selectedText = window.getSelection()?.toString().trim();
+      if (!selectedText) {
+        return;
+      }
+
+      event.clipboardData?.setData('text/plain', selectedText);
+      event.preventDefault();
+    });
+
+    window.addEventListener('message', (event) => {
+      if (!event.origin || event.origin === window.location.origin || event.origin === 'null') {
+        return;
+      }
+
+      Promise.reject(new Error('Message origin not allowed'));
+    });
+
+    window.setInterval(() => {
+      window.postMessage({ topic: 'fixture-noise' }, window.location.origin);
+    }, 25);
+  </script>
+</body>
+</html>

--- a/fixtures/selection-noisy.html
+++ b/fixtures/selection-noisy.html
@@ -38,7 +38,7 @@
         return;
       }
 
-      Promise.reject(new Error('Message origin not allowed'));
+      void Promise.reject(new Error('Message origin not allowed'));
     });
 
     window.setInterval(() => {

--- a/fixtures/selection-noisy.md
+++ b/fixtures/selection-noisy.md
@@ -1,0 +1,13 @@
+## Specs and Compatibility
+
+Technical Specifications
+
+##### Headphone
+
+-   **Driver:** 1.57 in(40mm) Biocellulose
+-   **Weight:** 10.22 oz(290 g)
+
+##### Battery & Charging
+
+-   **Battery type:** rechargeable
+-   **No lighting:** up to 90 hrs

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -95,6 +95,10 @@ export default async function copy(text: string, iframeSrc: string): Promise<Cop
     let settled = false;
     let timeoutId = 0;
 
+    const handleLoad = () => {
+      iframe.contentWindow?.postMessage({ cmd: 'copy', text: t }, '*', [channel.port2]);
+    };
+
     const cleanup = () => {
       iframe.removeEventListener('load', handleLoad);
       channel.port1.onmessage = null;
@@ -124,10 +128,6 @@ export default async function copy(text: string, iframeSrc: string): Promise<Cop
       } else {
         settle(() => reject(new KnownFailureError(event.data.reason || 'iframe copy failed')));
       }
-    };
-
-    const handleLoad = () => {
-      iframe.contentWindow?.postMessage({ cmd: 'copy', text: t }, '*', [channel.port2]);
     };
 
     iframe.addEventListener('load', handleLoad, { once: true });

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -61,7 +61,6 @@ export default async function copy(text: string, iframeSrc: string): Promise<Cop
       await navigator.clipboard.writeText(t);
       return true;
     }
-    console.debug(`clipboard-write permission state: ${ret?.state}`);
     throw new KnownFailureError('no permission to call navigator.clipboard API');
   };
 
@@ -92,29 +91,50 @@ export default async function copy(text: string, iframeSrc: string): Promise<Cop
     iframe.height = '10';
     iframe.style.position = 'absolute';
     iframe.style.left = '-100px';
-    document.body.appendChild(iframe);
-    window.addEventListener('message', (event) => {
-      switch (event.data.topic) {
-        case 'iframe-copy-response': {
-          if (document.body.contains(iframe)) {
-            document.body.removeChild(iframe);
-          }
-          if (event.data.ok) {
-            resolve(true);
-          } else {
-            reject(new KnownFailureError(event.data.reason));
-          }
-          break;
-        }
-        default: {
-          reject(new Error(`unknown topic ${event.data.topic}`));
-        }
-      }
-    });
+    const channel = new MessageChannel();
+    let settled = false;
+    let timeoutId = 0;
 
-    setTimeout(() => {
-      iframe.contentWindow?.postMessage({ cmd: 'copy', text: t }, '*');
-    }, 100);
+    const cleanup = () => {
+      iframe.removeEventListener('load', handleLoad);
+      channel.port1.onmessage = null;
+      channel.port1.close();
+      window.clearTimeout(timeoutId);
+      if (document.body.contains(iframe)) {
+        document.body.removeChild(iframe);
+      }
+    };
+
+    const settle = (fn: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      fn();
+    };
+
+    channel.port1.onmessage = (event: MessageEvent) => {
+      if (typeof event.data !== 'object' || event.data === null || event.data.topic !== 'iframe-copy-response') {
+        return;
+      }
+
+      if (event.data.ok) {
+        settle(() => resolve(true));
+      } else {
+        settle(() => reject(new KnownFailureError(event.data.reason || 'iframe copy failed')));
+      }
+    };
+
+    const handleLoad = () => {
+      iframe.contentWindow?.postMessage({ cmd: 'copy', text: t }, '*', [channel.port2]);
+    };
+
+    iframe.addEventListener('load', handleLoad, { once: true });
+    document.body.appendChild(iframe);
+    timeoutId = window.setTimeout(() => {
+      settle(() => reject(new KnownFailureError('iframe copy timed out')));
+    }, 5000);
   });
 
   try {
@@ -122,7 +142,6 @@ export default async function copy(text: string, iframeSrc: string): Promise<Cop
     return Promise.resolve({ ok: true, method: 'navigator_api' });
   } catch (error) {
     if (error instanceof KnownFailureError) {
-      console.debug(error);
       // try next method
     } else {
       const err = error as Error;
@@ -131,23 +150,22 @@ export default async function copy(text: string, iframeSrc: string): Promise<Cop
   }
 
   try {
-    await useOnPageTextarea(text);
-    return Promise.resolve({ ok: true, method: 'textarea' });
+    await useIframeTextarea(text);
+    return Promise.resolve({ ok: true, method: 'iframe' });
   } catch (error) {
     if (error instanceof KnownFailureError) {
-      console.debug(error);
       // try next method
     } else {
       const err = error as Error;
-      return Promise.resolve({ ok: false, error: `${err.name} ${err.message}`, method: 'textarea' });
+      return Promise.resolve({ ok: false, error: `${err.name} ${err.message}`, method: 'iframe' });
     }
   }
 
   try {
-    await useIframeTextarea(text);
-    return Promise.resolve({ ok: true, method: 'iframe' });
+    await useOnPageTextarea(text);
+    return Promise.resolve({ ok: true, method: 'textarea' });
   } catch (error) {
     const err = error as Error;
-    return Promise.resolve({ ok: false, error: `${err.name} ${err.message}`, method: 'iframe' });
+    return Promise.resolve({ ok: false, error: `${err.name} ${err.message}`, method: 'textarea' });
   }
 }

--- a/src/iframe-copy.ts
+++ b/src/iframe-copy.ts
@@ -9,48 +9,51 @@ interface CopyResponse {
   reason?: string;
 }
 
-window.addEventListener('message', (event: MessageEvent<CopyMessage>) => {
-  if (!event.source) {
-    throw new Error('No event source');
-  }
-  const options: WindowPostMessageOptions = {
-    targetOrigin: event.origin,
+window.addEventListener('message', async (event: MessageEvent<CopyMessage>) => {
+  const replyPort = event.ports[0];
+
+  const respond = (response: CopyResponse) => {
+    if (replyPort) {
+      replyPort.postMessage(response);
+      return;
+    }
+    if (!event.source) {
+      throw new Error('No reply channel');
+    }
+    event.source.postMessage(response, {
+      targetOrigin: '*',
+    });
   };
+
   switch (event.data.cmd) {
     case 'copy': {
       const { text } = event.data;
       if (text === '' || !text) {
-        event.source.postMessage(
-          { topic: 'iframe-copy-response', ok: false, reason: 'no text' } as CopyResponse,
-          options,
-        );
+        respond({ topic: 'iframe-copy-response', ok: false, reason: 'no text' } as CopyResponse);
         return;
       }
 
-      const textBox = document.getElementById('copy') as HTMLTextAreaElement;
-      textBox.value = text;
-      textBox.select();
-      const result = document.execCommand('Copy');
-      if (result) {
-        event.source.postMessage(
-          { topic: 'iframe-copy-response', ok: true } as CopyResponse,
-          options,
-        );
-      } else {
-        event.source.postMessage(
-          { topic: 'iframe-copy-response', ok: false, reason: 'execCommand returned false' } as CopyResponse,
-          options,
-        );
+      try {
+        await navigator.clipboard.writeText(text);
+        respond({ topic: 'iframe-copy-response', ok: true } as CopyResponse);
+        return;
+      } catch {
+        const textBox = document.getElementById('copy') as HTMLTextAreaElement;
+        textBox.value = text;
+        textBox.select();
+        const result = document.execCommand('Copy');
+        if (result) {
+          respond({ topic: 'iframe-copy-response', ok: true } as CopyResponse);
+        } else {
+          respond({ topic: 'iframe-copy-response', ok: false, reason: 'execCommand returned false' } as CopyResponse);
+        }
+        textBox.value = '';
       }
-      textBox.value = '';
       break;
     }
 
     default: {
-      event.source.postMessage(
-        { topic: 'iframe-copy-response', ok: false, reason: `unknown command ${event.data.cmd}` } as CopyResponse,
-        options,
-      );
+      respond({ topic: 'iframe-copy-response', ok: false, reason: `unknown command ${event.data.cmd}` } as CopyResponse);
     }
   }
 });

--- a/src/iframe-copy.ts
+++ b/src/iframe-copy.ts
@@ -21,7 +21,7 @@ window.addEventListener('message', async (event: MessageEvent<CopyMessage>) => {
       throw new Error('No reply channel');
     }
     event.source.postMessage(response, {
-      targetOrigin: '*',
+      targetOrigin: event.origin,
     });
   };
 

--- a/src/iframe-copy.ts
+++ b/src/iframe-copy.ts
@@ -36,7 +36,6 @@ window.addEventListener('message', async (event: MessageEvent<CopyMessage>) => {
       try {
         await navigator.clipboard.writeText(text);
         respond({ topic: 'iframe-copy-response', ok: true } as CopyResponse);
-        return;
       } catch {
         const textBox = document.getElementById('copy') as HTMLTextAreaElement;
         textBox.value = text;

--- a/test/e2e/clipboard/selection-as-markdown-smoke.spec.ts
+++ b/test/e2e/clipboard/selection-as-markdown-smoke.spec.ts
@@ -1,0 +1,77 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ConsoleMessage, Worker } from '@playwright/test';
+import { expect, test } from '../fixtures';
+import {
+  getServiceWorker,
+  resetSystemClipboard,
+  setMockClipboardMode,
+  waitForSystemClipboard,
+} from '../helpers';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n/g, '\n').trimEnd();
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Selection As Markdown Clipboard Smoke', () => {
+  let serviceWorker: Worker;
+
+  test.beforeEach(async ({ context }) => {
+    serviceWorker = await getServiceWorker(context);
+    await setMockClipboardMode(serviceWorker, false);
+    await context.clearPermissions();
+  });
+
+  test.beforeEach(async () => {
+    await resetSystemClipboard();
+  });
+
+  test.afterEach(async () => {
+    if (serviceWorker) {
+      await setMockClipboardMode(serviceWorker, true);
+    }
+  });
+
+  test('copies markdown through iframe fallback without page message interference', async ({ page }) => {
+    const consoleErrors: string[] = [];
+
+    page.on('console', (message: ConsoleMessage) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+    });
+
+    await page.goto('http://localhost:5566/selection-noisy.html');
+    await page.waitForLoadState('networkidle');
+
+    await page.evaluate(() => {
+      const range = document.createRange();
+      const content = document.querySelector('#content');
+      if (!content) {
+        throw new Error('Missing #content');
+      }
+      range.selectNodeContents(content);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+
+    await serviceWorker.evaluate(() => {
+      // @ts-expect-error - Chrome APIs are available in extension workers
+      return chrome.commands.onCommand.dispatch('selection-as-markdown');
+    });
+
+    await page.bringToFront();
+    const clipboardText = normalizeLineEndings(await waitForSystemClipboard(5000));
+    const expectedMarkdown = await readFile(join(__dirname, '../../../fixtures/selection-noisy.md'), 'utf-8');
+
+    expect(clipboardText).toEqual(normalizeLineEndings(expectedMarkdown));
+    expect(consoleErrors).toEqual(expect.not.arrayContaining([expect.stringContaining('Message origin not allowed')]));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug that you can reproduce by following these steps:

1. Open this URL: https://www.logitech.com/en-us/shop/p/astro-a20-x.939-002242
2. Click `Specs and Compatibility` button on the right.
3. In the opened right panel, select all the text (starting from "Specs and Compatibility" header to "Part Number"...)
4. Right click, click the "Copy selection as Markdown"
5. Paste copied contents anywhere to see that the text flattened to plain text:
```
Specs and Compatibility

Technical Specifications

Headphone
Driver: 1.57 in(40mm) Biocellulose
Headphone Frequency Response: 20 Hz-20 KHz
Weight: 10.22 oz(290 g)
PLAYSYNC Base: 2x up to 24 bit/48 kHz (PC) or up to 16 bit/48 kHz (console)
Microphone
Microphone type: Boom
Pick up pattern: Omni
Microphone Frequency response: 70 Hz-20 KHz
Battery & Charging
Battery type: rechargeable
No lighting: up to 90 hrs
Default lighting: up to 40 hrs
Connectivity
Connectivity Connection Type: LIGHTSPEED wireless via USB Bluetooth® 5.3 USB wired
Connectivity Wireless range: up to 1181 in(30 meters)
System Requirements
Compatibility: For LIGHTSPEED connection: Windows, macOS, or gaming console with an available USB 2.0 port. LIGHTSPEED Compatible with Xbox, PS5, PC, Nintendo Switch / Switch 2* *requires firmware update via G HUB on macOS or Windows For Bluetooth®️ connection: Compatible with devices supporting Bluetooth®️ 5.3 audio connectivity Additional software: Internet access required for G HUB and Logitech G Mobile App
Warranty Information

2-Year Limited Hardware Warranty
Part Number
```

Expected:
```md
## Specs and Compatibility

Technical Specifications

##### Headphone

-   **Driver:** 1.57 in(40mm) Biocellulose
-   **Headphone Frequency Response:** 20 Hz-20 KHz
-   **Weight:** 10.22 oz(290 g)
-   **PLAYSYNC Base:** 2x up to 24 bit/48 kHz (PC) or up to 16 bit/48 kHz (console)

##### Microphone

-   **Microphone type:** Boom
-   **Pick up pattern:** Omni
-   **Microphone Frequency response:** 70 Hz-20 KHz

##### Battery & Charging

-   **Battery type:** rechargeable
-   **No lighting:** up to 90 hrs
-   **Default lighting:** up to 40 hrs

##### Connectivity

-   **Connectivity Connection Type:** LIGHTSPEED wireless via USB Bluetooth® 5.3 USB wired
-   **Connectivity Wireless range:** up to 1181 in(30 meters)

##### System Requirements

-   **Compatibility:** For LIGHTSPEED connection: Windows, macOS, or gaming console with an available USB 2.0 port. LIGHTSPEED Compatible with Xbox, PS5, PC, Nintendo Switch / Switch 2\* \*requires firmware update via G HUB on macOS or Windows For Bluetooth®️ connection: Compatible with devices supporting Bluetooth®️ 5.3 audio connectivity Additional software: Internet access required for G HUB and Logitech G Mobile App

Warranty Information

2-Year Limited Hardware Warranty

Part Number
```

Turndown was not the problem here. The selected Logitech HTML still contained the expected headings and lists, and converting that HTML produced the correct Markdown.

The bug was in the Chromium clipboard fallback path after conversion. When `navigator.clipboard.writeText()` was not available from the injected content script, the extension fell back to an iframe helper and then, if that failed, to an on-page textarea copy. On noisy pages, unrelated `window.postMessage` traffic could disrupt the iframe response and push the flow into the weaker fallback. Once that happened, the page's own copy behavior could win and flatten the result to plain text.

This PR fixes this by:

- preferring the extension iframe clipboard path before the on-page textarea fallback
- changing the iframe helper to use `navigator.clipboard.writeText()` first, with `execCommand('Copy')` only as fallback
- replacing the iframe reply `window.postMessage` flow with a private `MessageChannel`, so unrelated page message listeners and origin checks do not interfere with the clipboard response

It also adds a real-clipboard regression smoke test on a noisy local fixture page. That fixture is meant to cover the fragile fallback/message-interference path, not to exactly reproduce the Logitech page.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [x] Chrome stable (Windows)
- [x] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)

Additional testing:

- Reproduced the bug manually on the real Logitech page with the current store build on Windows.
- Verified manually that the patched build copies Markdown correctly on the same Logitech page on Chrome stable on Windows.
- Verified manually that the patched build copies Markdown correctly on Firefox stable on Windows.
- Verified manually that the patched build copies Markdown correctly on Edge stable on Windows.
- Ran `npm test -- --project unit`
- Ran `npx playwright test --project=clipboard-smoke --no-deps test/e2e/clipboard/selection-as-markdown-smoke.spec.ts`

## AI Disclosure

<!-- Check one. Be honest. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [x] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [ ] I did not use any coding agent to create this patch. I am responsible for all the code I wrote.

AI was used in this PR to:

- inspect the selection-to-markdown and clipboard code paths in the local repository
- launch and inspect live browser sessions using Playwright automation / browser-debugging tools
- help reproduce and narrow the bug by checking the selected DOM, extension behavior, console output, and the real Windows clipboard during live runs
- propose and implement the clipboard fallback fix
- add the noisy-page real-clipboard regression test
- draft and revise this PR description

I manually reviewed the patch, reproduced the original issue, verified the fix on Windows browsers, and take responsibility for the final patch.
