### PR TITLE
Fix: prevent empty string copying

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -128,6 +128,10 @@ browser.alarms.onAlarm.addListener(async (alarm) => {
   }
 });
 
+browser.runtime.onStartup.addListener(async () => {
+  await clearPendingPopupFeedback();
+});
+
 contextMenuService.createAll().then(() => null /* NOP */);
 browser.storage.sync.onChanged.addListener(async (changes) => {
   const changedKeys = Object.keys(changes);

--- a/src/background.ts
+++ b/src/background.ts
@@ -82,6 +82,7 @@ const runtimeMessageHandler = createBrowserRuntimeMessageHandler(handlerServices
 async function setPendingPopupFeedback(feedback: PendingPopupFeedbackCode): Promise<void> {
   try {
     await pendingPopupFeedbackService.set(feedback);
+    await badgeService.showWarning();
   } catch (error) {
     console.error('Failed to persist pending popup feedback', error);
   }
@@ -90,6 +91,7 @@ async function setPendingPopupFeedback(feedback: PendingPopupFeedbackCode): Prom
 async function clearPendingPopupFeedback(): Promise<void> {
   try {
     await pendingPopupFeedbackService.clear();
+    await badgeService.clear();
   } catch (error) {
     console.error('Failed to clear pending popup feedback', error);
   }
@@ -112,7 +114,12 @@ async function refreshMarkdownInstance(): Promise<void> {
 
 browser.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === badgeService.getClearAlarmName()) {
-    await badgeService.clear();
+    const pendingPopupFeedback = await pendingPopupFeedbackService.get();
+    if (pendingPopupFeedback) {
+      await badgeService.showWarning();
+    } else {
+      await badgeService.clear();
+    }
   }
 
   if (alarm.name === ALARM_REFRESH_MENU) {
@@ -190,7 +197,12 @@ browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
   if (runtimeMessage.topic === 'consume-pending-popup-feedback') {
     pendingPopupFeedbackService.consume()
-      .then(feedback => sendResponse({ ok: true, text: null, feedback }))
+      .then(async (feedback) => {
+        if (feedback) {
+          await badgeService.clear();
+        }
+        sendResponse({ ok: true, text: null, feedback });
+      })
       .catch(error => sendResponse({ ok: false, error: error.message }));
     return true;
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -201,7 +201,7 @@ browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         if (feedback) {
           await badgeService.clear();
         }
-        sendResponse({ ok: true, text: null, feedback });
+        sendResponse({ ok: true, feedback });
       })
       .catch(error => sendResponse({ ok: false, error: error.message }));
     return true;

--- a/src/background.ts
+++ b/src/background.ts
@@ -125,8 +125,10 @@ if (Flags.periodicallyRefreshMenu()) {
 browser.contextMenus.onClicked.addListener(async (info, tab) => {
   try {
     const text = await contextMenuHandler.handleMenuClick(info, tab);
-    await clipboardService.copy(text, tab);
-    await badgeService.showSuccess();
+    const didCopy = await clipboardService.copy(text, tab);
+    if (didCopy) {
+      await badgeService.showSuccess();
+    }
     return true;
   } catch (error) {
     console.error(error);
@@ -139,8 +141,10 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
 browser.commands.onCommand.addListener(async (command: string, tab?: browser.tabs.Tab) => {
   try {
     const text = await keyboardCommandHandler.handleCommand(command as KeyboardCommandId, tab);
-    await clipboardService.copy(text, tab);
-    await badgeService.showSuccess();
+    const didCopy = await clipboardService.copy(text, tab);
+    if (didCopy) {
+      await badgeService.showSuccess();
+    }
     return true;
   } catch (e) {
     console.error(e);
@@ -175,8 +179,9 @@ browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
   // Handle copy-to-clipboard message from popup
   if (runtimeMessage.topic === 'copy-to-clipboard') {
-    clipboardService.copy(runtimeMessage.params.text)
-      .then(() => sendResponse({ ok: true, text: null }))
+    const text = runtimeMessage.params.text;
+    clipboardService.copy(text)
+      .then(didCopy => sendResponse({ ok: true, text: null, copied: didCopy }))
       .catch(error => sendResponse({ ok: false, error: error.message }));
     return true;
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -10,11 +10,12 @@ import { createBrowserTabExportService } from './services/tab-export-service.js'
 import { createBrowserClipboardServiceController } from './services/clipboard-service.js';
 import { LinkExportService } from './services/link-export-service.js';
 import { createBrowserSelectionConverterService } from './services/selection-converter-service.js';
+import { createBrowserPendingPopupFeedbackService } from './services/pending-popup-feedback-service.js';
 import { createKeyboardBrowserCommandHandler } from './handlers/keyboard-command-handler.js';
 import { createBrowserContextMenuHandler } from './handlers/context-menu-handler.js';
 import { createBrowserRuntimeMessageHandler } from './handlers/runtime-message-handler.js';
 import type { KeyboardCommandId } from './contracts/commands.js';
-import type { RuntimeMessage } from './contracts/messages.js';
+import type { PendingPopupFeedbackCode, RuntimeMessage } from './contracts/messages.js';
 import { Flags } from './config/flags.js';
 
 const ALARM_REFRESH_MENU = 'refreshMenu';
@@ -35,6 +36,8 @@ const linkExportService = new LinkExportService(markdownInstance, CustomFormatsS
 // Check if ALWAYS_USE_NAVIGATOR_COPY_API flag is set
 const useNavigatorClipboard = Flags.alwaysUseNavigatorClipboard();
 const iframeCopyUrl = browser.runtime.getURL('dist/static/iframe-copy.html');
+const pendingPopupFeedbackService = createBrowserPendingPopupFeedbackService();
+const EMPTY_RESULT_FEEDBACK: PendingPopupFeedbackCode = 'empty-result';
 
 const clipboardService = createBrowserClipboardServiceController(
   useNavigatorClipboard ? navigator.clipboard : null,
@@ -75,6 +78,22 @@ const contextMenuHandler = createBrowserContextMenuHandler(
 
 // Runtime message handler
 const runtimeMessageHandler = createBrowserRuntimeMessageHandler(handlerServices);
+
+async function setPendingPopupFeedback(feedback: PendingPopupFeedbackCode): Promise<void> {
+  try {
+    await pendingPopupFeedbackService.set(feedback);
+  } catch (error) {
+    console.error('Failed to persist pending popup feedback', error);
+  }
+}
+
+async function clearPendingPopupFeedback(): Promise<void> {
+  try {
+    await pendingPopupFeedbackService.clear();
+  } catch (error) {
+    console.error('Failed to clear pending popup feedback', error);
+  }
+}
 
 async function refreshMarkdownInstance(): Promise<void> {
   let settings;
@@ -127,7 +146,10 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
     const text = await contextMenuHandler.handleMenuClick(info, tab);
     const didCopy = await clipboardService.copy(text, tab);
     if (didCopy) {
+      await clearPendingPopupFeedback();
       await badgeService.showSuccess();
+    } else {
+      await setPendingPopupFeedback(EMPTY_RESULT_FEEDBACK);
     }
     return true;
   } catch (error) {
@@ -143,7 +165,10 @@ browser.commands.onCommand.addListener(async (command: string, tab?: browser.tab
     const text = await keyboardCommandHandler.handleCommand(command as KeyboardCommandId, tab);
     const didCopy = await clipboardService.copy(text, tab);
     if (didCopy) {
+      await clearPendingPopupFeedback();
       await badgeService.showSuccess();
+    } else {
+      await setPendingPopupFeedback(EMPTY_RESULT_FEEDBACK);
     }
     return true;
   } catch (e) {
@@ -160,6 +185,13 @@ browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   // Handle check-mock-clipboard message from popup
   if (runtimeMessage.topic === 'check-mock-clipboard') {
     sendResponse({ ok: true, text: clipboardService.isMockMode() ? 'true' : 'false' });
+    return true;
+  }
+
+  if (runtimeMessage.topic === 'consume-pending-popup-feedback') {
+    pendingPopupFeedbackService.consume()
+      .then(feedback => sendResponse({ ok: true, text: null, feedback }))
+      .catch(error => sendResponse({ ok: false, error: error.message }));
     return true;
   }
 
@@ -181,7 +213,12 @@ browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (runtimeMessage.topic === 'copy-to-clipboard') {
     const text = runtimeMessage.params.text;
     clipboardService.copy(text)
-      .then(didCopy => sendResponse({ ok: true, text: null, copied: didCopy }))
+      .then(async (didCopy) => {
+        if (didCopy) {
+          await clearPendingPopupFeedback();
+        }
+        sendResponse({ ok: true, text: null, copied: didCopy });
+      })
       .catch(error => sendResponse({ ok: false, error: error.message }));
     return true;
   }

--- a/src/contracts/messages.ts
+++ b/src/contracts/messages.ts
@@ -3,6 +3,8 @@
  */
 import type { ExportTabsOptions } from '../services/tab-export-service.js';
 
+export type PendingPopupFeedbackCode = 'empty-result';
+
 export interface BadgeMessage {
   topic: 'badge';
   params: { type: 'success' | 'fail' };
@@ -37,13 +39,19 @@ export interface SetMockClipboardMessage {
   params: { enabled: boolean };
 }
 
+export interface ConsumePendingPopupFeedbackMessage {
+  topic: 'consume-pending-popup-feedback';
+  params: Record<string, never>;
+}
+
 export type RuntimeMessage
   = | BadgeMessage
     | ExportCurrentTabMessage
     | ExportTabsMessage
     | CopyToClipboardMessage
     | CheckMockClipboardMessage
-    | SetMockClipboardMessage;
+    | SetMockClipboardMessage
+    | ConsumePendingPopupFeedbackMessage;
 
 export type RuntimeMessageTopic = RuntimeMessage['topic'];
 

--- a/src/iframe-copy.ts
+++ b/src/iframe-copy.ts
@@ -29,6 +29,10 @@ window.addEventListener('message', async (event: MessageEvent<CopyMessage>) => {
     case 'copy': {
       const { text } = event.data;
       if (text === '' || !text) {
+        // NOTE: in this case the caller from content-script.ts would try the next method,
+        // but really since there is no text it should not try anymore.
+        // The call site should instead avoid calling clipboard service when the text is empty,
+        // becuase there is nothing that can be written to the clipboard.
         respond({ topic: 'iframe-copy-response', ok: false, reason: 'no text' } as CopyResponse);
         return;
       }

--- a/src/services/badge-service.ts
+++ b/src/services/badge-service.ts
@@ -3,10 +3,12 @@ type BadgeColor = string | ColorArray;
 
 const COLOR_GREEN = '#738a05';
 const COLOR_RED = '#d11b24';
+const COLOR_YELLOW = '#b7791f';
 const COLOR_TRANSPARENT: ColorArray = [0, 0, 0, 0];
 
 const TEXT_OK = '✓';
 const TEXT_ERROR = '×';
+const TEXT_WARNING = '!';
 const TEXT_EMPTY = '';
 
 const FLASH_DURATION_MS = 3000;
@@ -73,6 +75,17 @@ export function createBadgeService(
       ]);
       // Creating an alarm with the same name replaces any existing alarm
       alarmsAPI.create(ALARM_NAME_CLEAR_BADGE, { when: Date.now() + FLASH_DURATION_MS });
+    },
+
+    /**
+     * Shows a persistent warning badge (! with yellow background).
+     * This state is not auto-cleared and must be cleared explicitly.
+     */
+    async showWarning(): Promise<void> {
+      await Promise.all([
+        badgeAPI.setBadgeText({ text: TEXT_WARNING }),
+        badgeAPI.setBadgeBackgroundColor({ color: COLOR_YELLOW }),
+      ]);
     },
 
     /**

--- a/src/services/clipboard-service.ts
+++ b/src/services/clipboard-service.ts
@@ -121,6 +121,10 @@ export function createClipboardService(
   }
 
   async function copy_(text: string, tab?: browser.tabs.Tab): Promise<void> {
+    if (text === '') {
+      return;
+    }
+
     // If clipboardAPI is provided, use it directly (for ALWAYS_USE_NAVIGATOR_COPY_API mode)
     if (clipboardAPI) {
       await clipboardAPI.writeText(text);

--- a/src/services/clipboard-service.ts
+++ b/src/services/clipboard-service.ts
@@ -12,8 +12,9 @@ export interface ClipboardService {
   /**
    * Copy text to clipboard.
    * If tab is not provided, will attempt to get the current active tab.
+   * @returns `true` if the clipboard was updated, `false` for a no-op.
    */
-  copy: (text: string, tab?: browser.tabs.Tab) => Promise<void>;
+  copy: (text: string, tab?: browser.tabs.Tab) => Promise<boolean>;
 
   /**
    * Get all recorded clipboard copy calls (only available in mock mode)
@@ -56,27 +57,33 @@ export function createMockClipboardService(): ClipboardService {
   }
 
   // Helper to save calls to storage
-  async function saveCallsToStorage(calls: ClipboardMockCall[]): Promise<void> {
+  async function saveCallsToStorage(calls: ClipboardMockCall[]): Promise<boolean> {
     try {
       if (browser.storage?.session) {
         await browser.storage.session.set({ [STORAGE_KEY]: calls });
       } else {
         await browser.storage.local.set({ [STORAGE_KEY]: calls });
       }
+      return true;
     } catch (error) {
       console.error('Failed to save mock clipboard calls:', error);
+      return false;
     }
   }
 
   return {
-    copy: async (text: string, tab?: browser.tabs.Tab): Promise<void> => {
+    copy: async (text: string, tab?: browser.tabs.Tab): Promise<boolean> => {
+      if (text === '') {
+        return false;
+      }
+
       const calls = await getCallsFromStorage();
       calls.push({
         text,
         tab,
         timestamp: Date.now(),
       });
-      await saveCallsToStorage(calls);
+      return await saveCallsToStorage(calls);
     },
     getCalls: async () => {
       return await getCallsFromStorage();
@@ -97,7 +104,7 @@ export function createClipboardService(
   clipboardAPI: ClipboardAPI | null,
   iframeUrl: string,
 ): ClipboardService {
-  async function copyUsingContentScript(tab: browser.tabs.Tab, text: string): Promise<void> {
+  async function copyUsingContentScript(tab: browser.tabs.Tab, text: string): Promise<boolean> {
     if (!tab.id) {
       throw new Error('tab has no id');
     }
@@ -115,20 +122,20 @@ export function createClipboardService(
     }
     const { result } = firstResult;
     if (result.ok) {
-      return;
+      return true;
     }
     throw new Error(`content script failed: ${result.error} (method = ${result.method})`);
   }
 
-  async function copy_(text: string, tab?: browser.tabs.Tab): Promise<void> {
+  async function copy_(text: string, tab?: browser.tabs.Tab): Promise<boolean> {
     if (text === '') {
-      return;
+      return false;
     }
 
     // If clipboardAPI is provided, use it directly (for ALWAYS_USE_NAVIGATOR_COPY_API mode)
     if (clipboardAPI) {
       await clipboardAPI.writeText(text);
-      return;
+      return true;
     }
 
     // Otherwise use content script approach
@@ -137,8 +144,7 @@ export function createClipboardService(
     if (!targetTab) {
       targetTab = await mustGetCurrentTab(tabsAPI);
     }
-
-    await copyUsingContentScript(targetTab, text);
+    return await copyUsingContentScript(targetTab, text);
   }
 
   return {
@@ -251,8 +257,8 @@ export function createBrowserClipboardServiceController(
   }
 
   return {
-    copy: async (text: string, tab?: browser.tabs.Tab): Promise<void> => {
-      await activeService.copy(text, tab);
+    copy: async (text: string, tab?: browser.tabs.Tab): Promise<boolean> => {
+      return await activeService.copy(text, tab);
     },
     setMockMode,
     initializeMockState,

--- a/src/services/pending-popup-feedback-service.ts
+++ b/src/services/pending-popup-feedback-service.ts
@@ -1,0 +1,51 @@
+import type { PendingPopupFeedbackCode } from '../contracts/messages.js';
+
+export interface PendingPopupFeedbackService {
+  get: () => Promise<PendingPopupFeedbackCode | null>;
+  set: (feedback: PendingPopupFeedbackCode) => Promise<void>;
+  clear: () => Promise<void>;
+  consume: () => Promise<PendingPopupFeedbackCode | null>;
+}
+
+function isPendingPopupFeedbackCode(value: unknown): value is PendingPopupFeedbackCode {
+  return value === 'empty-result';
+}
+
+export function createPendingPopupFeedbackService(
+  storageArea: browser.storage.StorageArea,
+  storageKey = 'pendingPopupFeedback',
+): PendingPopupFeedbackService {
+  async function get(): Promise<PendingPopupFeedbackCode | null> {
+    const result = await storageArea.get(storageKey);
+    const feedback = result[storageKey];
+    return isPendingPopupFeedbackCode(feedback) ? feedback : null;
+  }
+
+  async function set(feedback: PendingPopupFeedbackCode): Promise<void> {
+    await storageArea.set({ [storageKey]: feedback });
+  }
+
+  async function clear(): Promise<void> {
+    await storageArea.remove(storageKey);
+  }
+
+  async function consume(): Promise<PendingPopupFeedbackCode | null> {
+    const feedback = await get();
+    if (feedback) {
+      await clear();
+    }
+    return feedback;
+  }
+
+  return {
+    get,
+    set,
+    clear,
+    consume,
+  };
+}
+
+export function createBrowserPendingPopupFeedbackService(): PendingPopupFeedbackService {
+  const storageArea = (browser.storage as any).session || browser.storage.local;
+  return createPendingPopupFeedbackService(storageArea);
+}

--- a/src/static/popup.html
+++ b/src/static/popup.html
@@ -29,7 +29,7 @@
 <div class="dropdown is-active">
   <div class="dropdown-menu is-relative p-0" id="dropdown-menu" role="menu">
     <div class="dropdown-content is-radiusless is-shadowless p-0">
-      <div id="flash-message" class="notification is-danger is-radiusless is-hidden mb-0">
+      <div id="flash-message" class="notification is-radiusless is-hidden mb-0">
         <button class="delete" aria-label="Close notification"></button>
         <span id="flash-text"></span>
       </div>

--- a/src/static/popup.html
+++ b/src/static/popup.html
@@ -7,19 +7,30 @@
   <link rel="stylesheet" href="./style.css">
   <style>
   :root {
-    --bulma-body-min-width: 240px;
+    --popup-width: 240px;
+    --popup-min-width: 240px;
   }
 
   /* Keep the dropdown as wide as the popup, even when only short labels remain */
+  html,
   body,
   .dropdown,
   #dropdown-menu,
   .dropdown-content {
-    width: 100%;
-    min-width: var(--bulma-body-min-width);
+    width: var(--popup-width);
+    min-width: var(--popup-min-width);
+    max-width: var(--popup-width);
   }
   .dropdown-content .dropdown-item {
     width: 100%;
+  }
+  #flash-message {
+    white-space: normal;
+    overflow-wrap: break-word;
+    padding-right: 3rem;
+  }
+  #flash-text {
+    display: block;
   }
 
   </style>

--- a/src/static/popup.html
+++ b/src/static/popup.html
@@ -7,8 +7,7 @@
   <link rel="stylesheet" href="./style.css">
   <style>
   :root {
-    --popup-width: 240px;
-    --popup-min-width: 240px;
+    --popup-width: 250px;
   }
 
   /* Keep the dropdown as wide as the popup, even when only short labels remain */
@@ -18,7 +17,7 @@
   #dropdown-menu,
   .dropdown-content {
     width: var(--popup-width);
-    min-width: var(--popup-min-width);
+    min-width: var(--popup-width);
     max-width: var(--popup-width);
   }
   .dropdown-content .dropdown-item {

--- a/src/static/popup.html
+++ b/src/static/popup.html
@@ -23,6 +23,11 @@
   }
   .dropdown-content .dropdown-item {
     width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    text-align: left;
+    height: auto;
   }
   #flash-message {
     white-space: normal;

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -11,6 +11,9 @@ interface MessageResponse {
   error?: string;
 }
 
+type FlashKind = 'error' | 'warning';
+type ExportOutcome = 'copied' | 'empty';
+
 const URL_PARAMS = new URLSearchParams(window.location.search);
 let windowId = -1;
 let tabId = -1;
@@ -32,11 +35,14 @@ const flashText = document.getElementById('flash-text');
 function hideFlash(): void {
   if (!flash) return;
   flash.classList.add('is-hidden');
+  flash.classList.remove('is-danger', 'is-warning');
   if (flashText) flashText.textContent = '';
 }
 
-function showFlash(message: string): void {
+function showFlash(kind: FlashKind, message: string): void {
   if (!flash) return;
+  flash.classList.remove('is-danger', 'is-warning');
+  flash.classList.add(kind === 'error' ? 'is-danger' : 'is-warning');
   flash.classList.remove('is-hidden');
   if (flashText) flashText.textContent = message;
 }
@@ -106,9 +112,9 @@ async function sendMessage(message: RuntimeMessage): Promise<MessageResponse> {
   return response;
 }
 
-async function handleExportResponse(text: string): Promise<boolean> {
+async function handleExportResponse(text: string): Promise<ExportOutcome> {
   if (text === '') {
-    return false;
+    return 'empty';
   }
 
   if (useMockClipboard) {
@@ -119,11 +125,11 @@ async function handleExportResponse(text: string): Promise<boolean> {
     if (!clipboardResponse?.ok) {
       throw new Error(clipboardResponse?.error || 'Mock clipboard copy failed');
     }
-    return clipboardResponse.copied ?? true;
+    return clipboardResponse.copied === false ? 'empty' : 'copied';
   }
 
   await navigator.clipboard.writeText(text);
-  return true;
+  return 'copied';
 }
 
 async function sendBadgeSafe(type: 'success' | 'fail'): Promise<void> {
@@ -140,14 +146,17 @@ async function sendBadgeSafe(type: 'success' | 'fail'): Promise<void> {
 async function performExport(message: RuntimeMessage): Promise<void> {
   try {
     const response = await sendMessage(message);
-    const didCopy = await handleExportResponse(response.text ?? '');
-    if (didCopy) {
+    const outcome = await handleExportResponse(response.text ?? '');
+    if (outcome === 'copied') {
       await sendBadgeSafe('success');
+      hideFlash();
       if (!keepOpen) {
         window.close();
       }
+      return;
     }
-    hideFlash();
+
+    showFlash('warning', 'Nothing to copy. This format rendered empty text.');
   } catch (error) {
     // @ts-expect-error - browser.runtime.lastError is not in types
     browser.runtime.lastError = error;
@@ -155,7 +164,7 @@ async function performExport(message: RuntimeMessage): Promise<void> {
     if (isTabsPermissionError(error)) {
       return;
     }
-    showFlash('Failed to copy to clipboard. Please try again.');
+    showFlash('error', 'Failed to copy to clipboard. Please try again.');
   }
 }
 
@@ -383,7 +392,7 @@ document.addEventListener('DOMContentLoaded', () => {
       hideFlash();
     } catch (error) {
       console.error('Failed to initialize popup', error);
-      showFlash('Failed to load tabs or settings. Please reopen the popup.');
+      showFlash('error', 'Failed to load tabs or settings. Please reopen the popup.');
     }
   })();
 

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -1,4 +1,4 @@
-import type { RuntimeMessage } from '../contracts/messages.js';
+import type { PendingPopupFeedbackCode, RuntimeMessage } from '../contracts/messages.js';
 import type { ExportFormat, ExportScope, ListType } from '../services/tab-export-service.js';
 import CustomFormatsStorage from '../storage/custom-formats-storage.js';
 import type { BuiltInStyleSettings } from '../lib/built-in-style-settings.js';
@@ -8,6 +8,7 @@ interface MessageResponse {
   ok: boolean;
   text?: string;
   copied?: boolean;
+  feedback?: PendingPopupFeedbackCode | null;
   error?: string;
 }
 
@@ -45,6 +46,16 @@ function showFlash(kind: FlashKind, message: string): void {
   flash.classList.add(kind === 'error' ? 'is-danger' : 'is-warning');
   flash.classList.remove('is-hidden');
   if (flashText) flashText.textContent = message;
+}
+
+function pendingPopupFeedbackMessage(feedback: PendingPopupFeedbackCode): { kind: FlashKind; message: string } {
+  switch (feedback) {
+    case 'empty-result':
+      return {
+        kind: 'warning',
+        message: 'Nothing to copy. The last command produced empty text.',
+      };
+  }
 }
 
 function setButtonsDisabled(disabled: boolean): void {
@@ -234,6 +245,15 @@ async function checkMockClipboardAvailable(): Promise<boolean> {
   }
 }
 
+async function consumePendingPopupFeedback(): Promise<PendingPopupFeedbackCode | null> {
+  const response = await sendMessage({
+    topic: 'consume-pending-popup-feedback',
+    params: {},
+  } satisfies RuntimeMessage);
+
+  return response.feedback ?? null;
+}
+
 async function getCurrentWindow(): Promise<browser.windows.Window> {
   if (URL_PARAMS.has('window')) {
     const windowIdParam = URL_PARAMS.get('window');
@@ -387,9 +407,15 @@ document.addEventListener('DOMContentLoaded', () => {
       applyBuiltInVisibility(styles);
 
       await loadCustomFormats();
+      const pendingFeedback = await consumePendingPopupFeedback();
       ready = true;
       setButtonsDisabled(false);
-      hideFlash();
+      if (pendingFeedback) {
+        const flashFeedback = pendingPopupFeedbackMessage(pendingFeedback);
+        showFlash(flashFeedback.kind, flashFeedback.message);
+      } else {
+        hideFlash();
+      }
     } catch (error) {
       console.error('Failed to initialize popup', error);
       showFlash('error', 'Failed to load tabs or settings. Please reopen the popup.');

--- a/src/ui/popup.ts
+++ b/src/ui/popup.ts
@@ -7,6 +7,7 @@ import BuiltInStyleSettingsStorage from '../lib/built-in-style-settings.js';
 interface MessageResponse {
   ok: boolean;
   text?: string;
+  copied?: boolean;
   error?: string;
 }
 
@@ -105,7 +106,11 @@ async function sendMessage(message: RuntimeMessage): Promise<MessageResponse> {
   return response;
 }
 
-async function handleExportResponse(text: string): Promise<void> {
+async function handleExportResponse(text: string): Promise<boolean> {
+  if (text === '') {
+    return false;
+  }
+
   if (useMockClipboard) {
     const clipboardResponse = await browser.runtime.sendMessage({
       topic: 'copy-to-clipboard',
@@ -114,9 +119,11 @@ async function handleExportResponse(text: string): Promise<void> {
     if (!clipboardResponse?.ok) {
       throw new Error(clipboardResponse?.error || 'Mock clipboard copy failed');
     }
-  } else {
-    await navigator.clipboard.writeText(text);
+    return clipboardResponse.copied ?? true;
   }
+
+  await navigator.clipboard.writeText(text);
+  return true;
 }
 
 async function sendBadgeSafe(type: 'success' | 'fail'): Promise<void> {
@@ -133,14 +140,14 @@ async function sendBadgeSafe(type: 'success' | 'fail'): Promise<void> {
 async function performExport(message: RuntimeMessage): Promise<void> {
   try {
     const response = await sendMessage(message);
-    if (response.text) {
-      await handleExportResponse(response.text);
+    const didCopy = await handleExportResponse(response.text ?? '');
+    if (didCopy) {
+      await sendBadgeSafe('success');
+      if (!keepOpen) {
+        window.close();
+      }
     }
-    await sendBadgeSafe('success');
     hideFlash();
-    if (!keepOpen) {
-      window.close();
-    }
   } catch (error) {
     // @ts-expect-error - browser.runtime.lastError is not in types
     browser.runtime.lastError = error;

--- a/test/e2e/formatting/tab-exporting-custom-format.spec.ts
+++ b/test/e2e/formatting/tab-exporting-custom-format.spec.ts
@@ -10,7 +10,13 @@
 
 import type { Page, Worker } from '@playwright/test';
 import { expect, test } from '../fixtures';
-import { getServiceWorker, resetMockClipboard, triggerContextMenu, waitForMockClipboard } from '../helpers';
+import {
+  getMockClipboardCalls,
+  getServiceWorker,
+  resetMockClipboard,
+  triggerContextMenu,
+  waitForMockClipboard,
+} from '../helpers';
 
 /**
  * Configure a custom format using the web UI
@@ -63,6 +69,28 @@ async function configureCustomFormatViaUI(
   await page.waitForTimeout(500);
 }
 
+async function openPopupWindow(serviceWorker: Worker, context: any, extensionId: string) {
+  await serviceWorker.evaluate(async (extId) => {
+    const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
+    if (!tabs[0]) {
+      throw new Error('No active tab found');
+    }
+    const windowId = tabs[0].windowId;
+    const popupUrl = `chrome-extension://${extId}/dist/static/popup.html?window=${windowId}`;
+
+    await chrome.windows.create({
+      url: popupUrl,
+      type: 'popup',
+      width: 400,
+      height: 600,
+    });
+  }, extensionId);
+
+  const popupWindow = await context.waitForEvent('page');
+  await popupWindow.waitForLoadState('networkidle');
+  return popupWindow;
+}
+
 test.describe('Custom Format', () => {
   let serviceWorker: Worker;
 
@@ -103,29 +131,7 @@ test.describe('Custom Format', () => {
     });
 
     test('should work with popup', async ({ page, context, extensionId }) => {
-      // Get window id from the current page's tab
-      await serviceWorker.evaluate(async (extensionId) => {
-        const tabs = await chrome.tabs.query({ currentWindow: true, active: true });
-        if (!tabs[0]) {
-          throw new Error('No active tab found');
-        }
-        const windowId = tabs[0].windowId;
-
-        // Open popup in a new window (not a new tab in the same window)
-        const popupUrl = `chrome-extension://${extensionId}/dist/static/popup.html?window=${windowId}`;
-
-        // Create a new window with the popup
-        await chrome.windows.create({
-          url: popupUrl,
-          type: 'popup',
-          width: 400,
-          height: 600,
-        });
-      }, extensionId);
-
-      // Wait for the new window and get its page
-      const popupWindow = await context.waitForEvent('page');
-      await popupWindow.waitForLoadState('networkidle');
+      const popupWindow = await openPopupWindow(serviceWorker, context, extensionId);
 
       // Click the button for current-tab-custom-format-1
       const button = popupWindow.locator('#current-tab-custom-format-1');
@@ -141,6 +147,36 @@ test.describe('Custom Format', () => {
 
       // Cleanup
       await popupWindow.close();
+    });
+
+    test('shows deferred popup warning once when keyboard command renders empty output', async ({ page, context, extensionId }) => {
+      await configureCustomFormatViaUI(page, extensionId, {
+        slot: '1',
+        context: 'single-link',
+        name: 'Empty Link',
+        template: '',
+        showInMenus: true,
+      });
+
+      await page.goto('http://localhost:5566/qa.html');
+      await page.waitForLoadState('networkidle');
+
+      await serviceWorker.evaluate(async () => {
+        // @ts-expect-error - Chrome APIs are available in service worker
+        chrome.commands.onCommand.dispatch('current-tab-custom-format-1');
+      });
+
+      await expect.poll(async () => {
+        return (await getMockClipboardCalls(serviceWorker)).length;
+      }).toBe(0);
+
+      const popupWindow = await openPopupWindow(serviceWorker, context, extensionId);
+      await expect(popupWindow.getByText('Nothing to copy. The last command produced empty text.')).toBeVisible();
+      await popupWindow.close();
+
+      const popupWindowAgain = await openPopupWindow(serviceWorker, context, extensionId);
+      await expect(popupWindowAgain.getByText('Nothing to copy. The last command produced empty text.')).toHaveCount(0);
+      await popupWindowAgain.close();
     });
   });
 

--- a/test/services/badge-service.test.ts
+++ b/test/services/badge-service.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBadgeService } from '../../src/services/badge-service.js';
+
+describe('badgeService', () => {
+  it('shows a success badge and schedules auto-clear', async () => {
+    const setBadgeText = vi.fn(async () => undefined);
+    const setBadgeBackgroundColor = vi.fn(async () => undefined);
+    const createAlarm = vi.fn();
+
+    const service = createBadgeService(
+      { setBadgeText, setBadgeBackgroundColor },
+      { create: createAlarm },
+    );
+
+    await service.showSuccess();
+
+    expect(setBadgeText).toHaveBeenCalledWith({ text: '✓' });
+    expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#738a05' });
+    expect(createAlarm).toHaveBeenCalledExactlyOnceWith(
+      service.getClearAlarmName(),
+      expect.objectContaining({ when: expect.any(Number) }),
+    );
+  });
+
+  it('shows an error badge and schedules auto-clear', async () => {
+    const setBadgeText = vi.fn(async () => undefined);
+    const setBadgeBackgroundColor = vi.fn(async () => undefined);
+    const createAlarm = vi.fn();
+
+    const service = createBadgeService(
+      { setBadgeText, setBadgeBackgroundColor },
+      { create: createAlarm },
+    );
+
+    await service.showError();
+
+    expect(setBadgeText).toHaveBeenCalledWith({ text: '×' });
+    expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#d11b24' });
+    expect(createAlarm).toHaveBeenCalledExactlyOnceWith(
+      service.getClearAlarmName(),
+      expect.objectContaining({ when: expect.any(Number) }),
+    );
+  });
+
+  it('shows a persistent warning badge without scheduling auto-clear', async () => {
+    const setBadgeText = vi.fn(async () => undefined);
+    const setBadgeBackgroundColor = vi.fn(async () => undefined);
+    const createAlarm = vi.fn();
+
+    const service = createBadgeService(
+      { setBadgeText, setBadgeBackgroundColor },
+      { create: createAlarm },
+    );
+
+    await service.showWarning();
+
+    expect(setBadgeText).toHaveBeenCalledWith({ text: '!' });
+    expect(setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#b7791f' });
+    expect(createAlarm).not.toHaveBeenCalled();
+  });
+});

--- a/test/services/clipboard-service.test.ts
+++ b/test/services/clipboard-service.test.ts
@@ -197,6 +197,51 @@ describe('clipboardService', () => {
       await expect(service.copy('test text')).rejects.toThrow('failed to get current tab');
     });
 
+    it('does nothing when text is empty string (clipboardAPI path)', async () => {
+      const writeTextMock = vi.fn<(text: string) => Promise<void>>(async () => {});
+      const mockClipboardAPI: ClipboardAPI = { writeText: writeTextMock };
+
+      const service = createClipboardService(
+        createUnusedScriptingAPI(),
+        createUnusedTabsAPI(),
+        mockClipboardAPI,
+        'chrome-extension://id/dist/static/iframe-copy.html',
+      );
+
+      await service.copy('');
+
+      expect(writeTextMock).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when text is empty string (content script path)', async () => {
+      const executeScriptMock = vi.fn(async () => [
+        { result: { ok: true, method: 'navigator_api' } },
+      ]);
+      const mockScriptingAPI: ScriptingAPI = { executeScript: executeScriptMock };
+
+      const service = createClipboardService(
+        mockScriptingAPI,
+        createUnusedTabsAPI(),
+        null,
+        'chrome-extension://id/dist/static/iframe-copy.html',
+      );
+
+      const tab: browser.tabs.Tab = {
+        id: 123,
+        index: 0,
+        pinned: false,
+        highlighted: false,
+        windowId: 1,
+        active: true,
+        incognito: false,
+        mutedInfo: { muted: false },
+      };
+
+      await service.copy('', tab);
+
+      expect(executeScriptMock).not.toHaveBeenCalled();
+    });
+
     it('should throw error when executeScript returns no results', async () => {
       const executeScriptMock = vi.fn(async () => []);
 

--- a/test/services/clipboard-service.test.ts
+++ b/test/services/clipboard-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createClipboardService } from '../../src/services/clipboard-service.js';
+import { createClipboardService, createMockClipboardService } from '../../src/services/clipboard-service.js';
 import type { ScriptingAPI } from '../../src/services/shared-types.js';
 import type {
   ClipboardAPI,
@@ -208,7 +208,7 @@ describe('clipboardService', () => {
         'chrome-extension://id/dist/static/iframe-copy.html',
       );
 
-      await service.copy('');
+      await expect(service.copy('')).resolves.toBe(false);
 
       expect(writeTextMock).not.toHaveBeenCalled();
     });
@@ -237,7 +237,7 @@ describe('clipboardService', () => {
         mutedInfo: { muted: false },
       };
 
-      await service.copy('', tab);
+      await expect(service.copy('', tab)).resolves.toBe(false);
 
       expect(executeScriptMock).not.toHaveBeenCalled();
     });
@@ -268,6 +268,63 @@ describe('clipboardService', () => {
       };
 
       await expect(service.copy('test text', tab)).rejects.toThrow('no result from content script');
+    });
+  });
+
+  describe('mock copy', () => {
+    it('records non-empty copies', async () => {
+      const sessionGetMock = vi.fn(async () => ({ mockClipboardCalls: [] }));
+      const sessionSetMock = vi.fn(async () => undefined);
+
+      (globalThis as any).browser = {
+        storage: {
+          session: {
+            get: sessionGetMock,
+            set: sessionSetMock,
+          },
+          local: {
+            get: vi.fn(),
+            set: vi.fn(),
+          },
+        },
+      };
+
+      const service = createMockClipboardService();
+
+      await expect(service.copy('test text')).resolves.toBe(true);
+
+      expect(sessionSetMock).toHaveBeenCalledExactlyOnceWith({
+        mockClipboardCalls: [
+          expect.objectContaining({
+            text: 'test text',
+          }),
+        ],
+      });
+    });
+
+    it('does not record empty-string copies', async () => {
+      const sessionGetMock = vi.fn(async () => ({ mockClipboardCalls: [] }));
+      const sessionSetMock = vi.fn(async () => undefined);
+
+      (globalThis as any).browser = {
+        storage: {
+          session: {
+            get: sessionGetMock,
+            set: sessionSetMock,
+          },
+          local: {
+            get: vi.fn(),
+            set: vi.fn(),
+          },
+        },
+      };
+
+      const service = createMockClipboardService();
+
+      await expect(service.copy('')).resolves.toBe(false);
+
+      expect(sessionGetMock).not.toHaveBeenCalled();
+      expect(sessionSetMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/services/pending-popup-feedback-service.test.ts
+++ b/test/services/pending-popup-feedback-service.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createPendingPopupFeedbackService,
+} from '../../src/services/pending-popup-feedback-service.js';
+
+function createStorageArea() {
+  const store = new Map<string, unknown>();
+
+  return {
+    storageArea: {
+      get: vi.fn(async (key: string) => ({ [key]: store.get(key) })),
+      set: vi.fn(async (items: Record<string, unknown>) => {
+        Object.entries(items).forEach(([key, value]) => {
+          store.set(key, value);
+        });
+      }),
+      remove: vi.fn(async (key: string) => {
+        store.delete(key);
+      }),
+    } as unknown as browser.storage.StorageArea,
+  };
+}
+
+describe('pendingPopupFeedbackService', () => {
+  it('stores and reads pending feedback', async () => {
+    const { storageArea } = createStorageArea();
+    const service = createPendingPopupFeedbackService(storageArea);
+
+    await service.set('empty-result');
+
+    await expect(service.get()).resolves.toBe('empty-result');
+  });
+
+  it('consumes feedback only once', async () => {
+    const { storageArea } = createStorageArea();
+    const service = createPendingPopupFeedbackService(storageArea);
+
+    await service.set('empty-result');
+
+    await expect(service.consume()).resolves.toBe('empty-result');
+    await expect(service.get()).resolves.toBeNull();
+    await expect(service.consume()).resolves.toBeNull();
+  });
+
+  it('clears pending feedback', async () => {
+    const { storageArea } = createStorageArea();
+    const service = createPendingPopupFeedbackService(storageArea);
+
+    await service.set('empty-result');
+    await service.clear();
+
+    await expect(service.get()).resolves.toBeNull();
+  });
+});

--- a/test/ui/popup.spec.ts
+++ b/test/ui/popup.spec.ts
@@ -38,6 +38,9 @@ function mockBrowser(tabs: browser.tabs.Tab[]) {
     if (message.topic === 'check-mock-clipboard') {
       return { ok: true, text: 'false' };
     }
+    if (message.topic === 'consume-pending-popup-feedback') {
+      return { ok: true, feedback: null };
+    }
     if (message.topic === 'export-current-tab' || message.topic === 'export-tabs') {
       return { ok: true, text: 'copied text' };
     }
@@ -216,5 +219,36 @@ describe('popup UI', () => {
     expect(flash?.classList.contains('is-danger')).toBe(true);
     expect(flash?.classList.contains('is-warning')).toBe(false);
     expect(closeMock).not.toHaveBeenCalled();
+  });
+
+  it('shows deferred feedback once when the popup opens', async () => {
+    const sendMessageMock = (globalThis as any).browser.runtime.sendMessage;
+    const flash = document.getElementById('flash-message');
+
+    sendMessageMock.mockImplementation(async (message: any) => {
+      if (message.topic === 'check-mock-clipboard') {
+        return { ok: true, text: 'false' };
+      }
+      if (message.topic === 'consume-pending-popup-feedback') {
+        return {
+          ok: true,
+          feedback: 'empty-result',
+        };
+      }
+      if (message.topic === 'badge') {
+        return { ok: true };
+      }
+      return { ok: true, text: 'copied text' };
+    });
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await (window as any).__popupReady;
+
+    await expect.element(page.getByText('Nothing to copy. The last command produced empty text.')).toBeVisible();
+    expect(flash?.classList.contains('is-warning')).toBe(true);
+    expect(sendMessageMock).toHaveBeenCalledWith({
+      topic: 'consume-pending-popup-feedback',
+      params: {},
+    });
   });
 });

--- a/test/ui/popup.spec.ts
+++ b/test/ui/popup.spec.ts
@@ -149,4 +149,39 @@ describe('popup UI', () => {
     expect(clipboardMock).toHaveBeenCalledWith('copied text');
     expect(closeMock).toHaveBeenCalled();
   });
+
+  it('does not show success or close the popup when export returns empty text', async () => {
+    const sendMessageMock = (globalThis as any).browser.runtime.sendMessage;
+    const clipboardMock = navigator.clipboard.writeText as ReturnType<typeof vi.fn>;
+    const closeMock = window.close as ReturnType<typeof vi.fn>;
+
+    sendMessageMock.mockClear();
+    clipboardMock.mockClear();
+    closeMock.mockClear();
+    sendMessageMock.mockImplementation(async (message: any) => {
+      if (message.topic === 'check-mock-clipboard') {
+        return { ok: true, text: 'false' };
+      }
+      if (message.topic === 'export-current-tab' || message.topic === 'export-tabs') {
+        return { ok: true, text: '' };
+      }
+      if (message.topic === 'copy-to-clipboard') {
+        return { ok: true, copied: false };
+      }
+      if (message.topic === 'badge') {
+        return { ok: true };
+      }
+      return { ok: true };
+    });
+
+    const button = page.getByRole('button', { name: 'Current tab link' });
+    await button.click();
+
+    expect(clipboardMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(expect.objectContaining({
+      topic: 'export-current-tab',
+    }));
+    expect(closeMock).not.toHaveBeenCalled();
+  });
 });

--- a/test/ui/popup.spec.ts
+++ b/test/ui/popup.spec.ts
@@ -154,6 +154,7 @@ describe('popup UI', () => {
     const sendMessageMock = (globalThis as any).browser.runtime.sendMessage;
     const clipboardMock = navigator.clipboard.writeText as ReturnType<typeof vi.fn>;
     const closeMock = window.close as ReturnType<typeof vi.fn>;
+    const flash = document.getElementById('flash-message');
 
     sendMessageMock.mockClear();
     clipboardMock.mockClear();
@@ -182,6 +183,38 @@ describe('popup UI', () => {
     expect(sendMessageMock).toHaveBeenCalledWith(expect.objectContaining({
       topic: 'export-current-tab',
     }));
+    expect(closeMock).not.toHaveBeenCalled();
+    await expect.element(page.getByText('Nothing to copy. This format rendered empty text.')).toBeVisible();
+    expect(flash?.classList.contains('is-warning')).toBe(true);
+    expect(flash?.classList.contains('is-danger')).toBe(false);
+  });
+
+  it('shows error styling when export fails', async () => {
+    const sendMessageMock = (globalThis as any).browser.runtime.sendMessage;
+    const closeMock = window.close as ReturnType<typeof vi.fn>;
+    const flash = document.getElementById('flash-message');
+
+    sendMessageMock.mockClear();
+    closeMock.mockClear();
+    sendMessageMock.mockImplementation(async (message: any) => {
+      if (message.topic === 'check-mock-clipboard') {
+        return { ok: true, text: 'false' };
+      }
+      if (message.topic === 'export-current-tab' || message.topic === 'export-tabs') {
+        return { ok: false, error: 'boom' };
+      }
+      if (message.topic === 'badge') {
+        return { ok: true };
+      }
+      return { ok: true };
+    });
+
+    const button = page.getByRole('button', { name: 'Current tab link' });
+    await button.click();
+
+    await expect.element(page.getByText('Failed to copy to clipboard. Please try again.')).toBeVisible();
+    expect(flash?.classList.contains('is-danger')).toBe(true);
+    expect(flash?.classList.contains('is-warning')).toBe(false);
     expect(closeMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

This PR improves how the extension handles commands that produce empty output, especially custom formats with empty templates.

Previously, these actions could fail silently or look like successful copies even though nothing was written to the clipboard. With this change, the extension now treats “empty result” as its own user-visible outcome.

User-facing changes:
- Popup actions that render empty text now keep the popup open and show a warning message instead of silently succeeding.
- Context-menu and keyboard-triggered actions that render empty text now leave a passive warning badge on the extension icon.
- That warning is paired with a deferred one-time message in the popup, so the next time the user opens the popup they see an explanation of what happened.
- Once the popup message is consumed or a later copy succeeds, the warning state is cleared.
- Popup layout was adjusted so warning messages wrap cleanly on Firefox without stretching the popup window, and long menu items also wrap instead of being cut off.

Behavioral improvements:
- Empty strings are no longer sent through clipboard write paths.
- Mock and real clipboard behavior now match, which improves consistency in tests and browser behavior.
- Stale warning state is cleared on browser startup.

Overall, this makes empty-output cases understandable and recoverable without interrupting the user with intrusive UI.
<img width="821" height="930" alt="截圖 2026-04-18 下午2 51 06" src="https://github.com/user-attachments/assets/48688baa-eded-4851-89df-e7d544972903" />
<img width="821" height="930" alt="截圖 2026-04-18 下午2 51 11" src="https://github.com/user-attachments/assets/88b2e3ab-5eca-4090-88a6-837102c13773" />

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [x] Chrome stable (macOS)
- [x] Firefox stable (macOS)
- [x] Chrome stable (Windows)
- [x] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)


## AI Disclosure

<!-- Check one. Be honest. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [x] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [ ] I did not use any coding agent to create this patch. I am responsible for all the code I wrote.
