### PR TITLE
Deprecate periodic refresh menu

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -24,8 +24,6 @@ import type { KeyboardCommandId } from './contracts/commands.js';
 import type { PendingPopupFeedbackCode, RuntimeMessage } from './contracts/messages.js';
 import { Flags } from './config/flags.js';
 
-const ALARM_REFRESH_MENU = 'refreshMenu';
-
 // Initialize markdown and bookmarks
 const markdownInstance = new Markdown();
 let selectionCodeBlockStyle: CodeBlockStyle = 'fenced';
@@ -137,11 +135,6 @@ browser.alarms.onAlarm.addListener(async (alarm) => {
       await badgeService.clear();
     }
   }
-
-  if (alarm.name === ALARM_REFRESH_MENU) {
-    await browser.contextMenus.removeAll();
-    await contextMenuService.createAll();
-  }
 });
 
 browser.runtime.onStartup.addListener(async () => {
@@ -158,13 +151,6 @@ browser.storage.sync.onChanged.addListener(async (changes) => {
     await contextMenuService.createAll();
   }
 });
-
-if (Flags.periodicallyRefreshMenu()) {
-  // Hack for Firefox, in which Context Menu disappears after some time.
-  // See https://discourse.mozilla.org/t/strange-mv3-behaviour-browser-runtime-oninstalled-event-and-menus-create/111208/7
-  console.info('Hack PERIDOCIALLY_REFRESH_MENU is enabled');
-  browser.alarms.create('refreshMenu', { periodInMinutes: 0.5 });
-}
 
 // NOTE: All listeners must be registered at top level scope.
 

--- a/src/config/flags.ts
+++ b/src/config/flags.ts
@@ -7,6 +7,5 @@ function getBooleanFlag(name: string): boolean {
 
 export const Flags = {
   alwaysUseNavigatorClipboard: () => getBooleanFlag('ALWAYS_USE_NAVIGATOR_COPY_API'),
-  periodicallyRefreshMenu: () => getBooleanFlag('PERIDOCIALLY_REFRESH_MENU'),
   convertMarkdownInBackground: () => getBooleanFlag('CONVERT_MARKDOWN_IN_BACKGROUND'),
 };


### PR DESCRIPTION
## Summary

It's an old workaround for Firefox MV3 which has since been resolved by Firefox.

See 46957e7cd938f26182412c51fd840b39827ba382 #196

The usage of the flag has been removed by 16d532bf17ac355525dd48d459fef72b74029a9a (#203) but i kept the production code just in case i need it back.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)


## AI Disclosure

<!-- Check one. Be honest. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [ ] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [ ] I did not use any coding agent to create this patch. I am responsible for all the code I wrote.
