### PR TITLE
ci: converge e2e env with Docker harness

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,6 +48,9 @@ jobs:
         run: |
           apt-get update && apt-get install -y xsel
       - name: Use Node.js
+        # Resolves .node-version (Node 24), matching the Node 24 shipped by the
+        # playwright container image above and the Docker e2e harness — keeps the
+        # e2e runtime identical across CI and local docker runs.
         uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -56,7 +59,10 @@ jobs:
       - name: Run Vitest UI tests in browser
         run: npm run test:browser
       - name: Run Playwright tests
-        run: xvfb-run -a npm run test:e2e
+        # Shared with the Docker harness so the xvfb invocation (screen geometry,
+        # RANDR) stays identical across CI and local docker runs. See
+        # docker/playwright-ci/run-playwright.sh and DEVELOPMENT.md (E2E tests).
+        run: bash docker/playwright-ci/run-playwright.sh
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:

--- a/.node-version
+++ b/.node-version
@@ -1,1 +1,1 @@
-lts/jod
+lts/krypton

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,6 +107,13 @@ This runs [docker/playwright-ci/docker-e2e.sh](docker/playwright-ci/docker-e2e.s
 3. Prunes only the dangling image this project's previous build orphaned (scoped by a Dockerfile
    `LABEL`), so other projects' images are never touched.
 
+**CI parity.** This harness and the GitHub Actions `playwright` job share one entrypoint —
+[docker/playwright-ci/run-playwright.sh](docker/playwright-ci/run-playwright.sh) — so the Xvfb
+invocation (screen geometry, RANDR extension) is identical locally and in CI. Both also run on the
+same Node: CI installs it from [`.node-version`](.node-version) via `setup-node`, and the Docker
+image inherits the matching Node from the Playwright base image. Keep these aligned when bumping
+either the base image or `.node-version`.
+
 With `CI=true`, Playwright retries failures (`retries: 2`) and writes machine-readable output. Read
 the result from **`test-results/results.json`**, not from scrolling stdout. The HTML report lands in
 `playwright-report/`.


### PR DESCRIPTION
Run the GitHub Actions playwright job through the shared docker/playwright-ci/run-playwright.sh entrypoint so the Xvfb invocation (screen geometry, RANDR) is identical in CI and local docker runs.

Bump .node-version lts/jod -> lts/krypton so all jobs and the Docker image run on Node 24, matching the Playwright base image.

Document the shared entrypoint and Node alignment in DEVELOPMENT.md.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>