### PR TITLE
Claude sandbox

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -175,6 +175,53 @@ Playwright suite above covers Chrome). It is **currently broken and not maintain
 fix when time allows. See [e2e_test/README.md](e2e_test/README.md). Don't rely on it for
 verifying changes yet; use the Playwright suite for e2e coverage in the meantime.
 
+## Claude Code sandbox (isolated `--dangerously-skip-permissions`)
+
+[docker/claude-sandbox/](docker/claude-sandbox/) provides an isolated container for running a
+Claude Code session with `claude --dangerously-skip-permissions` (full permissions, no prompts)
+without risking the host. It is built **from the same Playwright base image as the e2e harness**,
+so the *same* container runs the full gate **and** the e2e suite — no nested Docker.
+
+> The container protects your **host**, not the repo's git history: the working tree is
+> bind-mounted read-write (including `.git`). Your `~/.ssh`, `~/.aws`, `~/.npmrc`, and macOS
+> Keychain are **not** mounted.
+
+### Launch
+
+```sh
+docker/claude-sandbox/claude-sandbox.sh                 # build (first run) + drop into a shell
+docker/claude-sandbox/claude-sandbox.sh claude --dangerously-skip-permissions   # or launch Claude directly
+```
+
+First launch installs Linux-native `node_modules` into a named volume (the host's macOS
+`node_modules` is never used inside the container) and applies a default-deny network firewall
+that allows only the Anthropic API + auth, the npm registry, and GitHub.
+
+### Auth (log in once)
+
+A persisted login lives in a named volume. The default volume `claude-sandbox-home` is shared
+across sessions: **log in once** (run `claude` and complete the OAuth flow), and every later
+session — including separate dev tasks — reuses the token, which auto-refreshes. Set
+`CLAUDE_SANDBOX_HOME=<name>` to use an isolated home volume for a parallel/per-task sandbox (that
+volume needs its own one-time login). `ANTHROPIC_API_KEY` works as an alternative if you prefer
+not to log in interactively.
+
+### Running the gate and e2e inside the sandbox
+
+```sh
+npm run typecheck && npm run lint && npm test && npm run build   # gate
+CI=true bash docker/playwright-ci/run-playwright.sh              # e2e under Xvfb (CI parity)
+```
+
+The e2e path reuses the existing harness script — there is no separate npm script. `CI=true` is
+required so Playwright uses the non-blocking reporters (and writes `test-results/results.json`)
+instead of the auto-serving `html` report that would hang; the e2e Docker image sets this via
+`ENV`, but this general-purpose sandbox image does not. The container has its own Xvfb display and
+clipboard, so the clipboard-smoke project never touches your host clipboard. Results land in the
+bind-mounted `test-results/` and `playwright-report/` as usual; the known clipboard/tab-exporting
+flake is re-run in isolation with
+`CI=true xvfb-run -a npx playwright test --project=clipboard-smoke --retries=0`.
+
 ## Debugging the extension
 
 Auto-reload via esbuild `--watch` + `web-ext run`:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -222,6 +222,22 @@ bind-mounted `test-results/` and `playwright-report/` as usual; the known clipbo
 flake is re-run in isolation with
 `CI=true xvfb-run -a npx playwright test --project=clipboard-smoke --retries=0`.
 
+### Running on a Linux host (e.g. over SSH)
+
+The sandbox is cross-platform — a headless Linux box is a good place to run long unattended plan
+executions. The launcher already passes your host uid/gid into the container (so the
+bind-mounted tree stays writable on native Linux, where bind mounts are not uid-mapped) and adds
+the SELinux `:z` relabel automatically when SELinux is present. A few host requirements:
+
+- **Use rootful Docker.** The egress firewall needs `NET_ADMIN` + iptables/ipset in the
+  container's network namespace; rootless Docker restricts this and the allowlist won't apply.
+- **Kernel modules:** the host needs `ip_tables`/`ip_set` (standard on mainstream distros).
+- **Survive SSH drops:** run the launcher inside `tmux` or `screen`.
+- **Fully unattended runs:** use Claude's headless/print mode instead of the interactive TUI, e.g.
+  `docker/claude-sandbox/claude-sandbox.sh claude -p 'Execute the plan at docs/superpowers/plans/<file>.md' --dangerously-skip-permissions`.
+
+The same `claude-sandbox.sh` command works unchanged on both macOS and Linux.
+
 ## Debugging the extension
 
 Auto-reload via esbuild `--watch` + `web-ext run`:

--- a/docker/claude-sandbox/Dockerfile
+++ b/docker/claude-sandbox/Dockerfile
@@ -1,0 +1,41 @@
+# Sandbox image for running Claude Code with --dangerously-skip-permissions in isolation.
+# Built FROM the same Playwright base as docker/playwright-ci/Dockerfile so the SAME container
+# can run the full gate AND the e2e suite under Xvfb — no nested Docker. Keep the base image tag
+# aligned with docker/playwright-ci/Dockerfile and .node-version when bumping either.
+FROM mcr.microsoft.com/playwright:v1.57.0-noble
+
+# Label so host-side pruning (claude-sandbox.sh) can scope to this project's images only.
+LABEL com.copy-as-markdown.image=claude-sandbox
+
+# Tooling:
+#   xsel              - clipboard for the e2e clipboard-smoke project (matches the e2e image)
+#   iptables, ipset   - default-deny egress firewall applied at container start
+#   jq, dnsutils      - firewall script: parse GitHub IP ranges, resolve allowlisted hostnames
+#   ca-certificates   - TLS roots for curl/gh/npm
+# The entrypoint drops from root to pwuser with `setpriv`, which ships in util-linux in the base
+# image — so it is intentionally NOT in this install list (no added dependency).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      xsel iptables ipset jq dnsutils ca-certificates curl gnupg \
+  && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (gh) from the official apt repo.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI (global).
+RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /workspace
+
+# Firewall + entrypoint scripts.
+COPY docker/claude-sandbox/init-firewall.sh /usr/local/bin/init-firewall.sh
+COPY docker/claude-sandbox/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/claude-sandbox/claude-sandbox.sh
+++ b/docker/claude-sandbox/claude-sandbox.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Host-side launcher for the Claude Code sandbox.
+#
+# Builds the image, ensures the named volumes exist, and runs the container with the network
+# caps + mounts the sandbox needs. The working tree is bind-mounted read-write at /workspace
+# (including .git); node_modules and ~/.claude are named volumes. NOTHING else from $HOME is
+# mounted — not ~/.ssh, ~/.aws, ~/.npmrc, nor the macOS Keychain.
+#
+# Auth: a persisted login lives in the home volume. Default volume `claude-sandbox-home` is
+# shared across sessions — log in once, reused everywhere (token auto-refreshes). Set
+# CLAUDE_SANDBOX_HOME=<name> to use an isolated home volume for a parallel/per-task sandbox
+# (that volume needs its own one-time login).
+#
+# Usage:
+#   docker/claude-sandbox/claude-sandbox.sh                 # build + drop into a shell
+#   docker/claude-sandbox/claude-sandbox.sh claude --dangerously-skip-permissions
+#   CLAUDE_SANDBOX_HOME=task-foo docker/claude-sandbox/claude-sandbox.sh
+#
+# Any arguments are passed through as the container command (default: bash).
+set -uo pipefail
+
+IMAGE=copy-as-markdown-claude-sandbox
+LABEL=com.copy-as-markdown.image=claude-sandbox
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+HOME_VOLUME="claude-sandbox-home${CLAUDE_SANDBOX_HOME:+-$CLAUDE_SANDBOX_HOME}"
+NODE_MODULES_VOLUME="claude-sandbox-node-modules"
+
+docker build -t "$IMAGE" -f "$ROOT/docker/claude-sandbox/Dockerfile" "$ROOT" || exit $?
+
+docker volume create "$HOME_VOLUME" >/dev/null
+docker volume create "$NODE_MODULES_VOLUME" >/dev/null
+
+echo "[sandbox] home volume: $HOME_VOLUME   node_modules volume: $NODE_MODULES_VOLUME"
+
+# Allocate an interactive TTY only when we actually have one (so a piped/non-interactive
+# `claude-sandbox.sh some-command` still works instead of erroring "input device is not a TTY").
+# The `[@]+...` guard keeps the empty-array expansion safe under `set -u` on bash 3.2 (macOS).
+tty_flags=()
+[ -t 0 ] && [ -t 1 ] && tty_flags=(-it)
+
+docker run --rm ${tty_flags[@]+"${tty_flags[@]}"} \
+  --cap-add=NET_ADMIN --cap-add=NET_RAW \
+  --shm-size=1g \
+  -v "$ROOT":/workspace \
+  -v "$NODE_MODULES_VOLUME":/workspace/node_modules \
+  -v "$HOME_VOLUME":/home/pwuser/.claude \
+  "$IMAGE" "$@"
+code=$?
+
+# Prune dangling images orphaned by this project's previous sandbox builds (label-scoped).
+docker image prune -f --filter "label=$LABEL" >/dev/null 2>&1 || true
+
+exit "$code"

--- a/docker/claude-sandbox/claude-sandbox.sh
+++ b/docker/claude-sandbox/claude-sandbox.sh
@@ -33,6 +33,17 @@ docker volume create "$NODE_MODULES_VOLUME" >/dev/null
 
 echo "[sandbox] home volume: $HOME_VOLUME   node_modules volume: $NODE_MODULES_VOLUME"
 
+# Match the in-container user to the host user so the bind-mounted working tree stays writable.
+# On native Linux, bind mounts pass through real uid/gid with NO mapping, so this is REQUIRED;
+# on macOS Docker Desktop ownership is auto-mapped and passing these is a harmless no-op.
+host_uid="$(id -u)"
+host_gid="$(id -g)"
+
+# SELinux hosts (RHEL/Fedora/Rocky) deny container access to bind mounts unless the mount is
+# relabeled with `:z`. Only add it when SELinux is actually present (no-op/absent elsewhere).
+workspace_mount="$ROOT:/workspace"
+[ -d /sys/fs/selinux ] && workspace_mount="$workspace_mount:z"
+
 # Allocate an interactive TTY only when we actually have one (so a piped/non-interactive
 # `claude-sandbox.sh some-command` still works instead of erroring "input device is not a TTY").
 # The `[@]+...` guard keeps the empty-array expansion safe under `set -u` on bash 3.2 (macOS).
@@ -42,7 +53,8 @@ tty_flags=()
 docker run --rm ${tty_flags[@]+"${tty_flags[@]}"} \
   --cap-add=NET_ADMIN --cap-add=NET_RAW \
   --shm-size=1g \
-  -v "$ROOT":/workspace \
+  -e SANDBOX_UID="$host_uid" -e SANDBOX_GID="$host_gid" \
+  -v "$workspace_mount" \
   -v "$NODE_MODULES_VOLUME":/workspace/node_modules \
   -v "$HOME_VOLUME":/home/pwuser/.claude \
   "$IMAGE" "$@"

--- a/docker/claude-sandbox/entrypoint.sh
+++ b/docker/claude-sandbox/entrypoint.sh
@@ -1,19 +1,50 @@
 #!/bin/bash
 # Entrypoint runs as root (required for iptables). It applies the firewall, prepares the
 # mounted volumes, installs Linux-native node_modules on first run / lockfile change, then drops
-# to the non-root pwuser to run the requested command (default: bash).
+# to a non-root user to run the requested command (default: bash).
+#
+# Cross-platform uid/gid: the launcher passes SANDBOX_UID/SANDBOX_GID = the HOST user's uid/gid.
+# On native Linux, bind mounts pass through real uid/gid with no mapping, so the dropped user must
+# match the host owner or it cannot write to /workspace. On macOS Docker Desktop ownership is
+# auto-mapped, so this is harmless there. Defaults to 1001 (the base image's pwuser) when unset.
 #
 # Privilege drop uses `setpriv` (from util-linux, already in the Playwright base image — zero
 # added dependency). Like gosu, it does a clean exec-based drop, so signals and exit codes pass
-# straight through to the child. `--init-groups` initializes pwuser's supplementary groups. The
-# numeric uid/gid 1001 is pwuser in this base image (kept literal for portability).
+# straight through to the child.
 #
 # setpriv changes ONLY process credentials, not the environment — so we must set HOME/USER for
 # the dropped child via `env`. Without it HOME stays /root: npm hits EACCES on /root/.npm, and
-# Claude Code would look for ~/.claude in /root instead of the mounted /home/pwuser volume.
+# Claude Code would look for ~/.claude in /root instead of the mounted home volume.
 set -euo pipefail
 
-SANDBOX_USER=pwuser   # used below only for chown/mkdir of the mounted volumes
+SANDBOX_UID="${SANDBOX_UID:-1001}"
+SANDBOX_GID="${SANDBOX_GID:-1001}"
+SANDBOX_HOME=/home/pwuser
+
+# Ensure the target uid maps to a named user. A host uid with no /etc/passwd entry (macOS 501,
+# or a Linux uid not baked into the image) makes whoami, git, and Node's os.userInfo() fail —
+# the last can crash Claude Code. If the uid already resolves (e.g. the default 1001 = pwuser),
+# reuse that name; otherwise create one so --init-groups and passwd lookups work.
+sandbox_name="$(getent passwd "$SANDBOX_UID" 2>/dev/null | cut -d: -f1 || true)"
+if [ -z "$sandbox_name" ]; then
+  getent group "$SANDBOX_GID" >/dev/null 2>&1 || groupadd -o -g "$SANDBOX_GID" ccsandbox
+  useradd -o -u "$SANDBOX_UID" -g "$SANDBOX_GID" -d "$SANDBOX_HOME" -M -s /bin/bash ccsandbox
+  sandbox_name=ccsandbox
+fi
+
+# The command prefix that drops root → the host-matched user with a correct environment.
+drop=(setpriv --reuid="$SANDBOX_UID" --regid="$SANDBOX_GID" --init-groups
+      env "HOME=$SANDBOX_HOME" "USER=$sandbox_name" "LOGNAME=$sandbox_name")
+
+# chown -R only when ownership doesn't already match (avoids paying the recursive cost every
+# start, and re-homes a volume first created under a different uid — e.g. moved between hosts).
+fix_owner() {
+  local target="$1"
+  [ -e "$target" ] || return 0
+  if [ "$(stat -c '%u' "$target" 2>/dev/null)" != "$SANDBOX_UID" ]; then
+    chown -R "$SANDBOX_UID:$SANDBOX_GID" "$target"
+  fi
+}
 
 # 1. Apply the egress firewall. Requires --cap-add=NET_ADMIN; warn (don't fail) if unavailable
 #    so the container is still usable for a no-network inspection.
@@ -27,9 +58,11 @@ else
   echo "[sandbox] not root; skipping firewall" >&2
 fi
 
-# 2. Make the named volumes writable by the non-root user.
-mkdir -p "/home/$SANDBOX_USER/.claude" /workspace/node_modules
-chown "$SANDBOX_USER:$SANDBOX_USER" "/home/$SANDBOX_USER/.claude" /workspace/node_modules || true
+# 2. Make the mounted volumes owned by the dropped user.
+mkdir -p "$SANDBOX_HOME/.claude" /workspace/node_modules
+chown "$SANDBOX_UID:$SANDBOX_GID" "$SANDBOX_HOME" 2>/dev/null || true
+fix_owner "$SANDBOX_HOME/.claude"
+fix_owner /workspace/node_modules
 
 # 3. Install dependencies into the node_modules volume when the lockfile hash changes.
 if [ -f /workspace/package-lock.json ]; then
@@ -37,15 +70,12 @@ if [ -f /workspace/package-lock.json ]; then
   stamp=/workspace/node_modules/.lock-hash
   if [ ! -f "$stamp" ] || [ "$(cat "$stamp" 2>/dev/null)" != "$lock_hash" ]; then
     echo "[sandbox] installing dependencies (npm ci)..."
-    setpriv --reuid=1001 --regid=1001 --init-groups \
-      env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" bash -lc 'cd /workspace && npm ci'
-    echo "$lock_hash" | setpriv --reuid=1001 --regid=1001 --init-groups \
-      env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" tee "$stamp" >/dev/null
+    "${drop[@]}" bash -lc 'cd /workspace && npm ci'
+    echo "$lock_hash" | "${drop[@]}" tee "$stamp" >/dev/null
   else
     echo "[sandbox] dependencies up to date"
   fi
 fi
 
 # 4. Drop privileges and run the requested command.
-exec setpriv --reuid=1001 --regid=1001 --init-groups \
-  env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" "$@"
+exec "${drop[@]}" "$@"

--- a/docker/claude-sandbox/entrypoint.sh
+++ b/docker/claude-sandbox/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Entrypoint runs as root (required for iptables). It applies the firewall, prepares the
+# mounted volumes, installs Linux-native node_modules on first run / lockfile change, then drops
+# to the non-root pwuser to run the requested command (default: bash).
+#
+# Privilege drop uses `setpriv` (from util-linux, already in the Playwright base image — zero
+# added dependency). Like gosu, it does a clean exec-based drop, so signals and exit codes pass
+# straight through to the child. `--init-groups` initializes pwuser's supplementary groups. The
+# numeric uid/gid 1001 is pwuser in this base image (kept literal for portability).
+#
+# setpriv changes ONLY process credentials, not the environment — so we must set HOME/USER for
+# the dropped child via `env`. Without it HOME stays /root: npm hits EACCES on /root/.npm, and
+# Claude Code would look for ~/.claude in /root instead of the mounted /home/pwuser volume.
+set -euo pipefail
+
+SANDBOX_USER=pwuser   # used below only for chown/mkdir of the mounted volumes
+
+# 1. Apply the egress firewall. Requires --cap-add=NET_ADMIN; warn (don't fail) if unavailable
+#    so the container is still usable for a no-network inspection.
+if [ "$(id -u)" = "0" ]; then
+  if /usr/local/bin/init-firewall.sh; then
+    echo "[sandbox] firewall applied"
+  else
+    echo "[sandbox] WARNING: firewall failed to apply (did you pass --cap-add=NET_ADMIN?)" >&2
+  fi
+else
+  echo "[sandbox] not root; skipping firewall" >&2
+fi
+
+# 2. Make the named volumes writable by the non-root user.
+mkdir -p "/home/$SANDBOX_USER/.claude" /workspace/node_modules
+chown "$SANDBOX_USER:$SANDBOX_USER" "/home/$SANDBOX_USER/.claude" /workspace/node_modules || true
+
+# 3. Install dependencies into the node_modules volume when the lockfile hash changes.
+if [ -f /workspace/package-lock.json ]; then
+  lock_hash="$(sha256sum /workspace/package-lock.json | cut -d' ' -f1)"
+  stamp=/workspace/node_modules/.lock-hash
+  if [ ! -f "$stamp" ] || [ "$(cat "$stamp" 2>/dev/null)" != "$lock_hash" ]; then
+    echo "[sandbox] installing dependencies (npm ci)..."
+    setpriv --reuid=1001 --regid=1001 --init-groups \
+      env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" bash -lc 'cd /workspace && npm ci'
+    echo "$lock_hash" | setpriv --reuid=1001 --regid=1001 --init-groups \
+      env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" tee "$stamp" >/dev/null
+  else
+    echo "[sandbox] dependencies up to date"
+  fi
+fi
+
+# 4. Drop privileges and run the requested command.
+exec setpriv --reuid=1001 --regid=1001 --init-groups \
+  env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" "$@"

--- a/docker/claude-sandbox/init-firewall.sh
+++ b/docker/claude-sandbox/init-firewall.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Default-deny outbound egress with an allowlist, applied at container start (needs root +
+# --cap-add=NET_ADMIN). Allows: DNS, loopback, established connections, and a fixed set of
+# hosts (Anthropic API + auth, npm registry, GitHub). Everything else is dropped.
+#
+# PROVENANCE: derived from Anthropic's reference Claude Code devcontainer firewall:
+#   https://github.com/anthropics/claude-code/blob/main/.devcontainer/init-firewall.sh
+#   (derived 2026-06-20). This is a vendored copy — Anthropic does not distribute it as a
+#   package. To check for upstream improvements, diff this file against that URL periodically.
+#   Local deltas from upstream: simplified to IPv4-only ipset (no `aggregate` dependency) and a
+#   fixed hostname allowlist instead of reading domains from a config file.
+#
+# Resolution (dig/curl) runs BEFORE the default policy flips to DROP, so it relies on the
+# post-flush default-ACCEPT state. Order matters — do not move the policy lines up.
+set -euo pipefail
+IFS=$'\n\t'
+
+echo "[firewall] resetting rules..."
+iptables -F
+iptables -X
+iptables -t nat -F 2>/dev/null || true
+iptables -t mangle -F 2>/dev/null || true
+ipset destroy allowed-domains 2>/dev/null || true
+
+# Loopback always allowed.
+iptables -A INPUT  -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# DNS must work before we resolve allowlisted hostnames.
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A INPUT  -p udp --sport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+iptables -A INPUT  -p tcp --sport 53 -j ACCEPT
+
+ipset create allowed-domains hash:net family inet
+
+# --- GitHub IP ranges (web + api + git) from the meta API. IPv4 CIDRs only (ipset family inet).
+echo "[firewall] fetching GitHub IP ranges..."
+gh_meta="$(curl -fsS https://api.github.com/meta || echo '{}')"
+echo "$gh_meta" | jq -r '[.web[]?, .api[]?, .git[]?] | .[]' 2>/dev/null \
+  | grep -E '^[0-9]+(\.[0-9]+){3}/[0-9]+$' \
+  | while read -r cidr; do ipset add allowed-domains "$cidr" 2>/dev/null || true; done
+
+# --- Hostname allowlist. Resolve A records and add each IP.
+for domain in \
+  registry.npmjs.org \
+  api.anthropic.com \
+  console.anthropic.com \
+  claude.ai \
+  statsig.anthropic.com \
+  github.com \
+  api.github.com \
+  codeload.github.com \
+  objects.githubusercontent.com; do
+  echo "[firewall] resolving $domain..."
+  for ip in $(dig +short A "$domain" | grep -E '^[0-9]+(\.[0-9]+){3}$' || true); do
+    ipset add allowed-domains "$ip" 2>/dev/null || true
+  done
+done
+
+# Allow established/related and traffic to the allowlisted set.
+iptables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Lock down: drop everything not explicitly allowed above.
+iptables -P INPUT   DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT  DROP
+
+echo "[firewall] active. Allowlisted entries: $(ipset list allowed-domains | grep -c '^[0-9]')"

--- a/docs/superpowers/plans/2026-06-20-claude-sandbox.md
+++ b/docs/superpowers/plans/2026-06-20-claude-sandbox.md
@@ -392,7 +392,13 @@ docker volume create "$NODE_MODULES_VOLUME" >/dev/null
 
 echo "[sandbox] home volume: $HOME_VOLUME   node_modules volume: $NODE_MODULES_VOLUME"
 
-docker run --rm -it \
+# Allocate an interactive TTY only when we actually have one (so a piped/non-interactive
+# `claude-sandbox.sh some-command` still works instead of erroring "input device is not a TTY").
+# The `[@]+...` guard keeps the empty-array expansion safe under `set -u` on bash 3.2 (macOS).
+tty_flags=()
+[ -t 0 ] && [ -t 1 ] && tty_flags=(-it)
+
+docker run --rm ${tty_flags[@]+"${tty_flags[@]}"} \
   --cap-add=NET_ADMIN --cap-add=NET_RAW \
   --shm-size=1g \
   -v "$ROOT":/workspace \

--- a/docs/superpowers/plans/2026-06-20-claude-sandbox.md
+++ b/docs/superpowers/plans/2026-06-20-claude-sandbox.md
@@ -258,19 +258,50 @@ Replace the entire contents of `docker/claude-sandbox/entrypoint.sh` with:
 #!/bin/bash
 # Entrypoint runs as root (required for iptables). It applies the firewall, prepares the
 # mounted volumes, installs Linux-native node_modules on first run / lockfile change, then drops
-# to the non-root pwuser to run the requested command (default: bash).
+# to a non-root user to run the requested command (default: bash).
+#
+# Cross-platform uid/gid: the launcher passes SANDBOX_UID/SANDBOX_GID = the HOST user's uid/gid.
+# On native Linux, bind mounts pass through real uid/gid with no mapping, so the dropped user must
+# match the host owner or it cannot write to /workspace. On macOS Docker Desktop ownership is
+# auto-mapped, so this is harmless there. Defaults to 1001 (the base image's pwuser) when unset.
 #
 # Privilege drop uses `setpriv` (from util-linux, already in the Playwright base image — zero
 # added dependency). Like gosu, it does a clean exec-based drop, so signals and exit codes pass
-# straight through to the child. `--init-groups` initializes pwuser's supplementary groups. The
-# numeric uid/gid 1001 is pwuser in this base image (kept literal for portability).
+# straight through to the child.
 #
 # setpriv changes ONLY process credentials, not the environment — so we must set HOME/USER for
 # the dropped child via `env`. Without it HOME stays /root: npm hits EACCES on /root/.npm, and
-# Claude Code would look for ~/.claude in /root instead of the mounted /home/pwuser volume.
+# Claude Code would look for ~/.claude in /root instead of the mounted home volume.
 set -euo pipefail
 
-SANDBOX_USER=pwuser   # used below only for chown/mkdir of the mounted volumes
+SANDBOX_UID="${SANDBOX_UID:-1001}"
+SANDBOX_GID="${SANDBOX_GID:-1001}"
+SANDBOX_HOME=/home/pwuser
+
+# Ensure the target uid maps to a named user. A host uid with no /etc/passwd entry (macOS 501,
+# or a Linux uid not baked into the image) makes whoami, git, and Node's os.userInfo() fail —
+# the last can crash Claude Code. If the uid already resolves (e.g. the default 1001 = pwuser),
+# reuse that name; otherwise create one so --init-groups and passwd lookups work.
+sandbox_name="$(getent passwd "$SANDBOX_UID" 2>/dev/null | cut -d: -f1 || true)"
+if [ -z "$sandbox_name" ]; then
+  getent group "$SANDBOX_GID" >/dev/null 2>&1 || groupadd -o -g "$SANDBOX_GID" ccsandbox
+  useradd -o -u "$SANDBOX_UID" -g "$SANDBOX_GID" -d "$SANDBOX_HOME" -M -s /bin/bash ccsandbox
+  sandbox_name=ccsandbox
+fi
+
+# The command prefix that drops root → the host-matched user with a correct environment.
+drop=(setpriv --reuid="$SANDBOX_UID" --regid="$SANDBOX_GID" --init-groups
+      env "HOME=$SANDBOX_HOME" "USER=$sandbox_name" "LOGNAME=$sandbox_name")
+
+# chown -R only when ownership doesn't already match (avoids paying the recursive cost every
+# start, and re-homes a volume first created under a different uid — e.g. moved between hosts).
+fix_owner() {
+  local target="$1"
+  [ -e "$target" ] || return 0
+  if [ "$(stat -c '%u' "$target" 2>/dev/null)" != "$SANDBOX_UID" ]; then
+    chown -R "$SANDBOX_UID:$SANDBOX_GID" "$target"
+  fi
+}
 
 # 1. Apply the egress firewall. Requires --cap-add=NET_ADMIN; warn (don't fail) if unavailable
 #    so the container is still usable for a no-network inspection.
@@ -284,9 +315,11 @@ else
   echo "[sandbox] not root; skipping firewall" >&2
 fi
 
-# 2. Make the named volumes writable by the non-root user.
-mkdir -p "/home/$SANDBOX_USER/.claude" /workspace/node_modules
-chown "$SANDBOX_USER:$SANDBOX_USER" "/home/$SANDBOX_USER/.claude" /workspace/node_modules || true
+# 2. Make the mounted volumes owned by the dropped user.
+mkdir -p "$SANDBOX_HOME/.claude" /workspace/node_modules
+chown "$SANDBOX_UID:$SANDBOX_GID" "$SANDBOX_HOME" 2>/dev/null || true
+fix_owner "$SANDBOX_HOME/.claude"
+fix_owner /workspace/node_modules
 
 # 3. Install dependencies into the node_modules volume when the lockfile hash changes.
 if [ -f /workspace/package-lock.json ]; then
@@ -294,18 +327,15 @@ if [ -f /workspace/package-lock.json ]; then
   stamp=/workspace/node_modules/.lock-hash
   if [ ! -f "$stamp" ] || [ "$(cat "$stamp" 2>/dev/null)" != "$lock_hash" ]; then
     echo "[sandbox] installing dependencies (npm ci)..."
-    setpriv --reuid=1001 --regid=1001 --init-groups \
-      env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" bash -lc 'cd /workspace && npm ci'
-    echo "$lock_hash" | setpriv --reuid=1001 --regid=1001 --init-groups \
-      env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" tee "$stamp" >/dev/null
+    "${drop[@]}" bash -lc 'cd /workspace && npm ci'
+    echo "$lock_hash" | "${drop[@]}" tee "$stamp" >/dev/null
   else
     echo "[sandbox] dependencies up to date"
   fi
 fi
 
 # 4. Drop privileges and run the requested command.
-exec setpriv --reuid=1001 --regid=1001 --init-groups \
-  env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" "$@"
+exec "${drop[@]}" "$@"
 ```
 
 - [ ] **Step 2: Rebuild the image**
@@ -392,6 +422,17 @@ docker volume create "$NODE_MODULES_VOLUME" >/dev/null
 
 echo "[sandbox] home volume: $HOME_VOLUME   node_modules volume: $NODE_MODULES_VOLUME"
 
+# Match the in-container user to the host user so the bind-mounted working tree stays writable.
+# On native Linux, bind mounts pass through real uid/gid with NO mapping, so this is REQUIRED;
+# on macOS Docker Desktop ownership is auto-mapped and passing these is a harmless no-op.
+host_uid="$(id -u)"
+host_gid="$(id -g)"
+
+# SELinux hosts (RHEL/Fedora/Rocky) deny container access to bind mounts unless the mount is
+# relabeled with `:z`. Only add it when SELinux is actually present (no-op/absent elsewhere).
+workspace_mount="$ROOT:/workspace"
+[ -d /sys/fs/selinux ] && workspace_mount="$workspace_mount:z"
+
 # Allocate an interactive TTY only when we actually have one (so a piped/non-interactive
 # `claude-sandbox.sh some-command` still works instead of erroring "input device is not a TTY").
 # The `[@]+...` guard keeps the empty-array expansion safe under `set -u` on bash 3.2 (macOS).
@@ -401,7 +442,8 @@ tty_flags=()
 docker run --rm ${tty_flags[@]+"${tty_flags[@]}"} \
   --cap-add=NET_ADMIN --cap-add=NET_RAW \
   --shm-size=1g \
-  -v "$ROOT":/workspace \
+  -e SANDBOX_UID="$host_uid" -e SANDBOX_GID="$host_gid" \
+  -v "$workspace_mount" \
   -v "$NODE_MODULES_VOLUME":/workspace/node_modules \
   -v "$HOME_VOLUME":/home/pwuser/.claude \
   "$IMAGE" "$@"
@@ -426,7 +468,7 @@ Run a non-interactive smoke (override the default bash with a command; `-it` is 
 ```bash
 docker/claude-sandbox/claude-sandbox.sh bash -lc 'echo "user=$(whoami)"; ls /workspace/package.json; test -d /workspace/node_modules && echo "node_modules mounted"'
 ```
-Expected: image builds (or uses cache), volumes created, then `user=pwuser`, the path to `package.json`, and `node_modules mounted`. (First run also performs `npm ci`.)
+Expected: image builds (or uses cache), volumes created, then a `user=` line showing the in-container user mapped to your host uid (the baked-in `pwuser` when your uid is 1001, otherwise an auto-created `ccsandbox`), the path to `package.json`, and `node_modules mounted`. (First run also performs `npm ci`.)
 
 - [ ] **Step 4: Verify the per-task home-volume override**
 

--- a/docs/superpowers/plans/2026-06-20-claude-sandbox.md
+++ b/docs/superpowers/plans/2026-06-20-claude-sandbox.md
@@ -6,7 +6,7 @@
 
 **Architecture:** A new `docker/claude-sandbox/` image built **FROM the same Playwright base** as the e2e harness, so the container *is* the e2e environment (no nested Docker). An entrypoint applies an iptables/ipset firewall as root, installs Linux-native `node_modules` into a named volume, then drops to non-root `pwuser` to run the requested command. A host helper script wires up caps, mounts, and named volumes (working tree rw; `node_modules` and `~/.claude` as volumes; nothing else from `$HOME`).
 
-**Tech Stack:** Docker, bash, iptables/ipset, gosu, the Playwright `noble` base image (Node 24), `@anthropic-ai/claude-code`.
+**Tech Stack:** Docker, bash, iptables/ipset, `setpriv` (util-linux, privilege drop), the Playwright `noble` base image (Node 24), `@anthropic-ai/claude-code`.
 
 **Note on TDD:** This is declarative infra (Dockerfile + shell), so there are no unit tests to fail-first. Each task instead ends with **verification commands and their expected output** — run them and confirm before committing. Treat a failing verification exactly like a failing test: stop and fix before moving on.
 
@@ -15,7 +15,8 @@
 **Known facts (verified against the base image):**
 - Base image `mcr.microsoft.com/playwright:v1.57.0-noble` ships Node v24, `git`, `curl`.
 - Non-root user is **`pwuser`, uid/gid 1001**, home `/home/pwuser`.
-- Missing tools to install: `iptables`, `ipset`, `gosu`, `jq`, `dnsutils` (for `dig`), `gh`, `xsel`.
+- Missing tools to install: `iptables`, `ipset`, `jq`, `dnsutils` (for `dig`), `gh`, `xsel`.
+  (`setpriv`, used for the privilege drop, is already present via util-linux — no install.)
 - Playwright browsers live at `/ms-playwright` (preset via `PLAYWRIGHT_BROWSERS_PATH`); no browser download needed.
 
 ---
@@ -26,7 +27,7 @@
 |------|----------------|
 | `docker/claude-sandbox/Dockerfile` | Build the sandbox image FROM the Playwright base; add firewall/clipboard/CLI tooling + Claude Code. |
 | `docker/claude-sandbox/init-firewall.sh` | Default-deny iptables/ipset egress allowlist (Anthropic + npm + GitHub + DNS). |
-| `docker/claude-sandbox/entrypoint.sh` | (root) apply firewall → ensure volume ownership → `npm ci` into volume if lockfile changed → `exec gosu pwuser`. |
+| `docker/claude-sandbox/entrypoint.sh` | (root) apply firewall → ensure volume ownership → `npm ci` into volume if lockfile changed → `exec setpriv` to drop to pwuser. |
 | `docker/claude-sandbox/claude-sandbox.sh` | Host helper: build image, create volumes, `docker run` with caps/mounts. |
 | `DEVELOPMENT.md` | New section documenting how to launch the sandbox and run the gate + e2e. |
 
@@ -56,11 +57,12 @@ LABEL com.copy-as-markdown.image=claude-sandbox
 # Tooling:
 #   xsel              - clipboard for the e2e clipboard-smoke project (matches the e2e image)
 #   iptables, ipset   - default-deny egress firewall applied at container start
-#   gosu              - drop from root (needed for iptables) to non-root pwuser
 #   jq, dnsutils      - firewall script: parse GitHub IP ranges, resolve allowlisted hostnames
 #   ca-certificates   - TLS roots for curl/gh/npm
+# The entrypoint drops from root to pwuser with `setpriv`, which ships in util-linux in the base
+# image — so it is intentionally NOT in this install list (no added dependency).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      xsel iptables ipset gosu jq dnsutils ca-certificates curl gnupg \
+      xsel iptables ipset jq dnsutils ca-certificates curl gnupg \
   && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI (gh) from the official apt repo.
@@ -115,7 +117,7 @@ Expected: build completes successfully (`naming to ... copy-as-markdown-claude-s
 Run:
 ```bash
 docker run --rm copy-as-markdown-claude-sandbox bash -lc \
-  'id pwuser; claude --version; for t in iptables ipset gosu jq dig gh xsel; do command -v $t >/dev/null && echo "have $t" || echo "MISSING $t"; done'
+  'id pwuser; claude --version; for t in iptables ipset setpriv jq dig gh xsel; do command -v $t >/dev/null && echo "have $t" || echo "MISSING $t"; done'
 ```
 Expected: `uid=1001(pwuser)`, a Claude Code version string, and `have …` for every tool (no `MISSING`).
 
@@ -257,9 +259,18 @@ Replace the entire contents of `docker/claude-sandbox/entrypoint.sh` with:
 # Entrypoint runs as root (required for iptables). It applies the firewall, prepares the
 # mounted volumes, installs Linux-native node_modules on first run / lockfile change, then drops
 # to the non-root pwuser to run the requested command (default: bash).
+#
+# Privilege drop uses `setpriv` (from util-linux, already in the Playwright base image — zero
+# added dependency). Like gosu, it does a clean exec-based drop, so signals and exit codes pass
+# straight through to the child. `--init-groups` initializes pwuser's supplementary groups. The
+# numeric uid/gid 1001 is pwuser in this base image (kept literal for portability).
+#
+# setpriv changes ONLY process credentials, not the environment — so we must set HOME/USER for
+# the dropped child via `env`. Without it HOME stays /root: npm hits EACCES on /root/.npm, and
+# Claude Code would look for ~/.claude in /root instead of the mounted /home/pwuser volume.
 set -euo pipefail
 
-SANDBOX_USER=pwuser
+SANDBOX_USER=pwuser   # used below only for chown/mkdir of the mounted volumes
 
 # 1. Apply the egress firewall. Requires --cap-add=NET_ADMIN; warn (don't fail) if unavailable
 #    so the container is still usable for a no-network inspection.
@@ -283,15 +294,18 @@ if [ -f /workspace/package-lock.json ]; then
   stamp=/workspace/node_modules/.lock-hash
   if [ ! -f "$stamp" ] || [ "$(cat "$stamp" 2>/dev/null)" != "$lock_hash" ]; then
     echo "[sandbox] installing dependencies (npm ci)..."
-    gosu "$SANDBOX_USER" bash -lc 'cd /workspace && npm ci'
-    echo "$lock_hash" | gosu "$SANDBOX_USER" tee "$stamp" >/dev/null
+    setpriv --reuid=1001 --regid=1001 --init-groups \
+      env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" bash -lc 'cd /workspace && npm ci'
+    echo "$lock_hash" | setpriv --reuid=1001 --regid=1001 --init-groups \
+      env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" tee "$stamp" >/dev/null
   else
     echo "[sandbox] dependencies up to date"
   fi
 fi
 
 # 4. Drop privileges and run the requested command.
-exec gosu "$SANDBOX_USER" "$@"
+exec setpriv --reuid=1001 --regid=1001 --init-groups \
+  env "HOME=/home/$SANDBOX_USER" "USER=$SANDBOX_USER" "$@"
 ```
 
 - [ ] **Step 2: Rebuild the image**
@@ -310,9 +324,9 @@ docker run --rm --cap-add=NET_ADMIN --cap-add=NET_RAW --shm-size=1g \
   -v "$(pwd)":/workspace \
   -v claude-sandbox-test-nm:/workspace/node_modules \
   copy-as-markdown-claude-sandbox \
-  bash -lc 'whoami; node -e "require(\"esbuild\"); console.log(\"esbuild loads on linux OK\")"'
+  bash -lc 'whoami; echo "HOME=$HOME"; node -e "require(\"esbuild\"); console.log(\"esbuild loads on linux OK\")"'
 ```
-Expected: `[sandbox] firewall applied`, an `npm ci` run, then `pwuser` and `esbuild loads on linux OK` (proving Linux-native deps in the volume, not the host's darwin binaries).
+Expected: `[sandbox] firewall applied`, an `npm ci` run that **succeeds** (not an EACCES on `/root/.npm`), then `pwuser`, `HOME=/home/pwuser`, and `esbuild loads on linux OK` (proving the privilege drop sets HOME correctly and the Linux-native deps are in the volume, not the host's darwin binaries).
 
 - [ ] **Step 4: Verify second run skips reinstall**
 

--- a/docs/superpowers/plans/2026-06-20-claude-sandbox.md
+++ b/docs/superpowers/plans/2026-06-20-claude-sandbox.md
@@ -1,0 +1,544 @@
+# Containerized Claude Code Sandbox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A standalone Docker sandbox in which a Claude Code session can run `claude --dangerously-skip-permissions` and execute the full gate plus the e2e suite in one isolated container, with default-deny network egress and a persisted login.
+
+**Architecture:** A new `docker/claude-sandbox/` image built **FROM the same Playwright base** as the e2e harness, so the container *is* the e2e environment (no nested Docker). An entrypoint applies an iptables/ipset firewall as root, installs Linux-native `node_modules` into a named volume, then drops to non-root `pwuser` to run the requested command. A host helper script wires up caps, mounts, and named volumes (working tree rw; `node_modules` and `~/.claude` as volumes; nothing else from `$HOME`).
+
+**Tech Stack:** Docker, bash, iptables/ipset, gosu, the Playwright `noble` base image (Node 24), `@anthropic-ai/claude-code`.
+
+**Note on TDD:** This is declarative infra (Dockerfile + shell), so there are no unit tests to fail-first. Each task instead ends with **verification commands and their expected output** — run them and confirm before committing. Treat a failing verification exactly like a failing test: stop and fix before moving on.
+
+**Reference spec:** [docs/superpowers/specs/2026-06-20-claude-sandbox-design.md](../specs/2026-06-20-claude-sandbox-design.md)
+
+**Known facts (verified against the base image):**
+- Base image `mcr.microsoft.com/playwright:v1.57.0-noble` ships Node v24, `git`, `curl`.
+- Non-root user is **`pwuser`, uid/gid 1001**, home `/home/pwuser`.
+- Missing tools to install: `iptables`, `ipset`, `gosu`, `jq`, `dnsutils` (for `dig`), `gh`, `xsel`.
+- Playwright browsers live at `/ms-playwright` (preset via `PLAYWRIGHT_BROWSERS_PATH`); no browser download needed.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `docker/claude-sandbox/Dockerfile` | Build the sandbox image FROM the Playwright base; add firewall/clipboard/CLI tooling + Claude Code. |
+| `docker/claude-sandbox/init-firewall.sh` | Default-deny iptables/ipset egress allowlist (Anthropic + npm + GitHub + DNS). |
+| `docker/claude-sandbox/entrypoint.sh` | (root) apply firewall → ensure volume ownership → `npm ci` into volume if lockfile changed → `exec gosu pwuser`. |
+| `docker/claude-sandbox/claude-sandbox.sh` | Host helper: build image, create volumes, `docker run` with caps/mounts. |
+| `DEVELOPMENT.md` | New section documenting how to launch the sandbox and run the gate + e2e. |
+
+All work happens on the existing `claude-sandbox` branch.
+
+---
+
+## Task 1: Scaffold the sandbox image (Dockerfile)
+
+**Files:**
+- Create: `docker/claude-sandbox/Dockerfile`
+
+- [ ] **Step 1: Create the Dockerfile**
+
+Create `docker/claude-sandbox/Dockerfile` with exactly this content:
+
+```dockerfile
+# Sandbox image for running Claude Code with --dangerously-skip-permissions in isolation.
+# Built FROM the same Playwright base as docker/playwright-ci/Dockerfile so the SAME container
+# can run the full gate AND the e2e suite under Xvfb — no nested Docker. Keep the base image tag
+# aligned with docker/playwright-ci/Dockerfile and .node-version when bumping either.
+FROM mcr.microsoft.com/playwright:v1.57.0-noble
+
+# Label so host-side pruning (claude-sandbox.sh) can scope to this project's images only.
+LABEL com.copy-as-markdown.image=claude-sandbox
+
+# Tooling:
+#   xsel              - clipboard for the e2e clipboard-smoke project (matches the e2e image)
+#   iptables, ipset   - default-deny egress firewall applied at container start
+#   gosu              - drop from root (needed for iptables) to non-root pwuser
+#   jq, dnsutils      - firewall script: parse GitHub IP ranges, resolve allowlisted hostnames
+#   ca-certificates   - TLS roots for curl/gh/npm
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      xsel iptables ipset gosu jq dnsutils ca-certificates curl gnupg \
+  && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (gh) from the official apt repo.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI (global).
+RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /workspace
+
+# Firewall + entrypoint scripts (added in later tasks; COPY now so the image layout is fixed).
+COPY docker/claude-sandbox/init-firewall.sh /usr/local/bin/init-firewall.sh
+COPY docker/claude-sandbox/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["bash"]
+```
+
+- [ ] **Step 2: Create placeholder scripts so the COPY succeeds**
+
+The Dockerfile COPYs two scripts that later tasks fill in. Create minimal placeholders now so Task 1 builds:
+
+`docker/claude-sandbox/init-firewall.sh`:
+```bash
+#!/bin/bash
+echo "[firewall] placeholder — replaced in Task 2"
+```
+
+`docker/claude-sandbox/entrypoint.sh`:
+```bash
+#!/bin/bash
+exec "$@"
+```
+
+- [ ] **Step 3: Build the image**
+
+Run:
+```bash
+docker build -t copy-as-markdown-claude-sandbox -f docker/claude-sandbox/Dockerfile .
+```
+Expected: build completes successfully (`naming to ... copy-as-markdown-claude-sandbox`).
+
+- [ ] **Step 4: Verify the toolchain and Claude Code are present**
+
+Run:
+```bash
+docker run --rm copy-as-markdown-claude-sandbox bash -lc \
+  'id pwuser; claude --version; for t in iptables ipset gosu jq dig gh xsel; do command -v $t >/dev/null && echo "have $t" || echo "MISSING $t"; done'
+```
+Expected: `uid=1001(pwuser)`, a Claude Code version string, and `have …` for every tool (no `MISSING`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/claude-sandbox/Dockerfile docker/claude-sandbox/init-firewall.sh docker/claude-sandbox/entrypoint.sh
+git commit -m "feat(sandbox): scaffold Claude Code sandbox image"
+```
+
+---
+
+## Task 2: Network firewall (init-firewall.sh)
+
+**Files:**
+- Modify (replace placeholder): `docker/claude-sandbox/init-firewall.sh`
+
+- [ ] **Step 1: Write the firewall script**
+
+Replace the entire contents of `docker/claude-sandbox/init-firewall.sh` with:
+
+```bash
+#!/bin/bash
+# Default-deny outbound egress with an allowlist, applied at container start (needs root +
+# --cap-add=NET_ADMIN). Allows: DNS, loopback, established connections, and a fixed set of
+# hosts (Anthropic API + auth, npm registry, GitHub). Everything else is dropped.
+#
+# Resolution (dig/curl) runs BEFORE the default policy flips to DROP, so it relies on the
+# post-flush default-ACCEPT state. Order matters — do not move the policy lines up.
+set -euo pipefail
+IFS=$'\n\t'
+
+echo "[firewall] resetting rules..."
+iptables -F
+iptables -X
+iptables -t nat -F 2>/dev/null || true
+iptables -t mangle -F 2>/dev/null || true
+ipset destroy allowed-domains 2>/dev/null || true
+
+# Loopback always allowed.
+iptables -A INPUT  -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
+# DNS must work before we resolve allowlisted hostnames.
+iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
+iptables -A INPUT  -p udp --sport 53 -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+iptables -A INPUT  -p tcp --sport 53 -j ACCEPT
+
+ipset create allowed-domains hash:net family inet
+
+# --- GitHub IP ranges (web + api + git) from the meta API. IPv4 CIDRs only (ipset family inet).
+echo "[firewall] fetching GitHub IP ranges..."
+gh_meta="$(curl -fsS https://api.github.com/meta || echo '{}')"
+echo "$gh_meta" | jq -r '[.web[]?, .api[]?, .git[]?] | .[]' 2>/dev/null \
+  | grep -E '^[0-9]+(\.[0-9]+){3}/[0-9]+$' \
+  | while read -r cidr; do ipset add allowed-domains "$cidr" 2>/dev/null || true; done
+
+# --- Hostname allowlist. Resolve A records and add each IP.
+for domain in \
+  registry.npmjs.org \
+  api.anthropic.com \
+  console.anthropic.com \
+  claude.ai \
+  statsig.anthropic.com \
+  github.com \
+  api.github.com \
+  codeload.github.com \
+  objects.githubusercontent.com; do
+  echo "[firewall] resolving $domain..."
+  for ip in $(dig +short A "$domain" | grep -E '^[0-9]+(\.[0-9]+){3}$' || true); do
+    ipset add allowed-domains "$ip" 2>/dev/null || true
+  done
+done
+
+# Allow established/related and traffic to the allowlisted set.
+iptables -A INPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m set --match-set allowed-domains dst -j ACCEPT
+
+# Lock down: drop everything not explicitly allowed above.
+iptables -P INPUT   DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT  DROP
+
+echo "[firewall] active. Allowlisted entries: $(ipset list allowed-domains | grep -c '^[0-9]')"
+```
+
+- [ ] **Step 2: Rebuild the image with the real firewall**
+
+Run:
+```bash
+docker build -t copy-as-markdown-claude-sandbox -f docker/claude-sandbox/Dockerfile .
+```
+Expected: build succeeds.
+
+- [ ] **Step 3: Verify the firewall allows allowlisted hosts and blocks others**
+
+Run (note the caps — the firewall needs `NET_ADMIN`/`NET_RAW`):
+```bash
+docker run --rm --cap-add=NET_ADMIN --cap-add=NET_RAW copy-as-markdown-claude-sandbox bash -lc '
+  /usr/local/bin/init-firewall.sh
+  echo "--- allowlisted (expect 200/OK) ---"
+  curl -s -o /dev/null -w "registry.npmjs.org -> %{http_code}\n" https://registry.npmjs.org/ || true
+  curl -s -o /dev/null -w "api.github.com   -> %{http_code}\n" https://api.github.com/   || true
+  echo "--- blocked (expect timeout/failure) ---"
+  curl -s --max-time 5 -o /dev/null -w "example.com -> %{http_code}\n" https://example.com/ || echo "example.com -> BLOCKED (good)"
+'
+```
+Expected: `registry.npmjs.org -> 200` and `api.github.com -> 200` (or another 2xx/3xx), and `example.com -> BLOCKED (good)`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker/claude-sandbox/init-firewall.sh docker/claude-sandbox/Dockerfile
+git commit -m "feat(sandbox): default-deny egress firewall with allowlist"
+```
+
+---
+
+## Task 3: Entrypoint (firewall + deps + privilege drop)
+
+**Files:**
+- Modify (replace placeholder): `docker/claude-sandbox/entrypoint.sh`
+
+- [ ] **Step 1: Write the entrypoint**
+
+Replace the entire contents of `docker/claude-sandbox/entrypoint.sh` with:
+
+```bash
+#!/bin/bash
+# Entrypoint runs as root (required for iptables). It applies the firewall, prepares the
+# mounted volumes, installs Linux-native node_modules on first run / lockfile change, then drops
+# to the non-root pwuser to run the requested command (default: bash).
+set -euo pipefail
+
+SANDBOX_USER=pwuser
+
+# 1. Apply the egress firewall. Requires --cap-add=NET_ADMIN; warn (don't fail) if unavailable
+#    so the container is still usable for a no-network inspection.
+if [ "$(id -u)" = "0" ]; then
+  if /usr/local/bin/init-firewall.sh; then
+    echo "[sandbox] firewall applied"
+  else
+    echo "[sandbox] WARNING: firewall failed to apply (did you pass --cap-add=NET_ADMIN?)" >&2
+  fi
+else
+  echo "[sandbox] not root; skipping firewall" >&2
+fi
+
+# 2. Make the named volumes writable by the non-root user.
+mkdir -p "/home/$SANDBOX_USER/.claude" /workspace/node_modules
+chown "$SANDBOX_USER:$SANDBOX_USER" "/home/$SANDBOX_USER/.claude" /workspace/node_modules || true
+
+# 3. Install dependencies into the node_modules volume when the lockfile hash changes.
+if [ -f /workspace/package-lock.json ]; then
+  lock_hash="$(sha256sum /workspace/package-lock.json | cut -d' ' -f1)"
+  stamp=/workspace/node_modules/.lock-hash
+  if [ ! -f "$stamp" ] || [ "$(cat "$stamp" 2>/dev/null)" != "$lock_hash" ]; then
+    echo "[sandbox] installing dependencies (npm ci)..."
+    gosu "$SANDBOX_USER" bash -lc 'cd /workspace && npm ci'
+    echo "$lock_hash" | gosu "$SANDBOX_USER" tee "$stamp" >/dev/null
+  else
+    echo "[sandbox] dependencies up to date"
+  fi
+fi
+
+# 4. Drop privileges and run the requested command.
+exec gosu "$SANDBOX_USER" "$@"
+```
+
+- [ ] **Step 2: Rebuild the image**
+
+Run:
+```bash
+docker build -t copy-as-markdown-claude-sandbox -f docker/claude-sandbox/Dockerfile .
+```
+Expected: build succeeds.
+
+- [ ] **Step 3: Verify entrypoint installs deps and drops privileges**
+
+Run (mount the tree + a throwaway node_modules volume; first run will `npm ci`):
+```bash
+docker run --rm --cap-add=NET_ADMIN --cap-add=NET_RAW --shm-size=1g \
+  -v "$(pwd)":/workspace \
+  -v claude-sandbox-test-nm:/workspace/node_modules \
+  copy-as-markdown-claude-sandbox \
+  bash -lc 'whoami; node -e "require(\"esbuild\"); console.log(\"esbuild loads on linux OK\")"'
+```
+Expected: `[sandbox] firewall applied`, an `npm ci` run, then `pwuser` and `esbuild loads on linux OK` (proving Linux-native deps in the volume, not the host's darwin binaries).
+
+- [ ] **Step 4: Verify second run skips reinstall**
+
+Run the same command again. Expected: `[sandbox] dependencies up to date` (no second `npm ci`), then `pwuser` / `esbuild loads on linux OK`.
+
+- [ ] **Step 5: Clean up the throwaway volume**
+
+```bash
+docker volume rm claude-sandbox-test-nm
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker/claude-sandbox/entrypoint.sh
+git commit -m "feat(sandbox): entrypoint — firewall, deps, privilege drop"
+```
+
+---
+
+## Task 4: Host helper script (claude-sandbox.sh)
+
+**Files:**
+- Create: `docker/claude-sandbox/claude-sandbox.sh`
+
+- [ ] **Step 1: Write the helper**
+
+Create `docker/claude-sandbox/claude-sandbox.sh` with:
+
+```bash
+#!/usr/bin/env bash
+# Host-side launcher for the Claude Code sandbox.
+#
+# Builds the image, ensures the named volumes exist, and runs the container with the network
+# caps + mounts the sandbox needs. The working tree is bind-mounted read-write at /workspace
+# (including .git); node_modules and ~/.claude are named volumes. NOTHING else from $HOME is
+# mounted — not ~/.ssh, ~/.aws, ~/.npmrc, nor the macOS Keychain.
+#
+# Auth: a persisted login lives in the home volume. Default volume `claude-sandbox-home` is
+# shared across sessions — log in once, reused everywhere (token auto-refreshes). Set
+# CLAUDE_SANDBOX_HOME=<name> to use an isolated home volume for a parallel/per-task sandbox
+# (that volume needs its own one-time login).
+#
+# Usage:
+#   docker/claude-sandbox/claude-sandbox.sh                 # build + drop into a shell
+#   docker/claude-sandbox/claude-sandbox.sh claude --dangerously-skip-permissions
+#   CLAUDE_SANDBOX_HOME=task-foo docker/claude-sandbox/claude-sandbox.sh
+#
+# Any arguments are passed through as the container command (default: bash).
+set -uo pipefail
+
+IMAGE=copy-as-markdown-claude-sandbox
+LABEL=com.copy-as-markdown.image=claude-sandbox
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+HOME_VOLUME="claude-sandbox-home${CLAUDE_SANDBOX_HOME:+-$CLAUDE_SANDBOX_HOME}"
+NODE_MODULES_VOLUME="claude-sandbox-node-modules"
+
+docker build -t "$IMAGE" -f "$ROOT/docker/claude-sandbox/Dockerfile" "$ROOT" || exit $?
+
+docker volume create "$HOME_VOLUME" >/dev/null
+docker volume create "$NODE_MODULES_VOLUME" >/dev/null
+
+echo "[sandbox] home volume: $HOME_VOLUME   node_modules volume: $NODE_MODULES_VOLUME"
+
+docker run --rm -it \
+  --cap-add=NET_ADMIN --cap-add=NET_RAW \
+  --shm-size=1g \
+  -v "$ROOT":/workspace \
+  -v "$NODE_MODULES_VOLUME":/workspace/node_modules \
+  -v "$HOME_VOLUME":/home/pwuser/.claude \
+  "$IMAGE" "$@"
+code=$?
+
+# Prune dangling images orphaned by this project's previous sandbox builds (label-scoped).
+docker image prune -f --filter "label=$LABEL" >/dev/null 2>&1 || true
+
+exit "$code"
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run:
+```bash
+chmod +x docker/claude-sandbox/claude-sandbox.sh
+```
+
+- [ ] **Step 3: Verify the helper launches and mounts correctly**
+
+Run a non-interactive smoke (override the default bash with a command; `-it` is harmless here):
+```bash
+docker/claude-sandbox/claude-sandbox.sh bash -lc 'echo "user=$(whoami)"; ls /workspace/package.json; test -d /workspace/node_modules && echo "node_modules mounted"'
+```
+Expected: image builds (or uses cache), volumes created, then `user=pwuser`, the path to `package.json`, and `node_modules mounted`. (First run also performs `npm ci`.)
+
+- [ ] **Step 4: Verify the per-task home-volume override**
+
+Run:
+```bash
+CLAUDE_SANDBOX_HOME=demo docker/claude-sandbox/claude-sandbox.sh bash -lc 'true'
+docker volume ls | grep claude-sandbox-home
+```
+Expected: both `claude-sandbox-home-demo` (from this run) and, if you ran Step 3, `claude-sandbox-home` are listed. Clean up the demo volume: `docker volume rm claude-sandbox-home-demo`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/claude-sandbox/claude-sandbox.sh
+git commit -m "feat(sandbox): host launcher with caps, mounts, auth volume scoping"
+```
+
+---
+
+## Task 5: End-to-end verification — full gate + e2e inside the sandbox
+
+This task runs no new code; it proves the sandbox satisfies the spec's acceptance criteria. Nothing is committed unless a fix is needed.
+
+- [ ] **Step 1: Run the full gate inside the sandbox**
+
+Run:
+```bash
+docker/claude-sandbox/claude-sandbox.sh bash -lc \
+  'npm run typecheck && npm run lint && npm test && npm run build'
+```
+Expected: all four stages pass (tsc clean, eslint clean, vitest all green, both builds produced). The vitest `browser` project uses the base image's Chromium.
+
+- [ ] **Step 2: Run the e2e suite inside the sandbox via the existing harness script**
+
+Run (set `CI=true` — without it the Playwright config uses the auto-serving `html` reporter that **blocks forever** and never writes `results.json`; the e2e Docker image sets this via `ENV`, but the general-purpose sandbox image does not):
+```bash
+docker/claude-sandbox/claude-sandbox.sh bash -lc \
+  'CI=true bash docker/playwright-ci/run-playwright.sh'
+```
+Expected: the Playwright suite (both `parallel-tests` and `clipboard-smoke` projects) runs to completion under Xvfb using the **container's** clipboard, and the process exits with a real code. Read the authoritative result from `test-results/results.json` on the host:
+```bash
+jq '.suites[].specs[] | select(.ok==false)' test-results/results.json
+```
+Expected: no output (no failing specs). If the known clipboard/tab-exporting flake trips, re-run it in isolation inside the sandbox (still `CI=true` so the reporter doesn't hang; `--retries=0` overrides the CI retry count):
+```bash
+docker/claude-sandbox/claude-sandbox.sh bash -lc \
+  'CI=true xvfb-run -a npx playwright test --project=clipboard-smoke --retries=0'
+```
+
+- [ ] **Step 3: Confirm the host clipboard was untouched**
+
+The container uses its own Xvfb clipboard, so your host clipboard should be unchanged by Step 2. This is informational — no command needed beyond noting your host clipboard still holds whatever it did before.
+
+- [ ] **Step 4: No commit**
+
+This task only verifies. If any step failed and required a fix to a Task 1–4 file, commit that fix with a descriptive message and re-run the failed step.
+
+---
+
+## Task 6: Document the sandbox in DEVELOPMENT.md
+
+**Files:**
+- Modify: `DEVELOPMENT.md` (add a new section after "## E2E tests (Playwright)" / before "## Debugging the extension")
+
+- [ ] **Step 1: Add the sandbox section**
+
+Insert this section into `DEVELOPMENT.md` immediately before the `## Debugging the extension` heading:
+
+```markdown
+## Claude Code sandbox (isolated `--dangerously-skip-permissions`)
+
+[docker/claude-sandbox/](docker/claude-sandbox/) provides an isolated container for running a
+Claude Code session with `claude --dangerously-skip-permissions` (full permissions, no prompts)
+without risking the host. It is built **from the same Playwright base image as the e2e harness**,
+so the *same* container runs the full gate **and** the e2e suite — no nested Docker.
+
+> The container protects your **host**, not the repo's git history: the working tree is
+> bind-mounted read-write (including `.git`). Your `~/.ssh`, `~/.aws`, `~/.npmrc`, and macOS
+> Keychain are **not** mounted.
+
+### Launch
+
+```sh
+docker/claude-sandbox/claude-sandbox.sh                 # build (first run) + drop into a shell
+docker/claude-sandbox/claude-sandbox.sh claude --dangerously-skip-permissions   # or launch Claude directly
+```
+
+First launch installs Linux-native `node_modules` into a named volume (the host's macOS
+`node_modules` is never used inside the container) and applies a default-deny network firewall
+that allows only the Anthropic API + auth, the npm registry, and GitHub.
+
+### Auth (log in once)
+
+A persisted login lives in a named volume. The default volume `claude-sandbox-home` is shared
+across sessions: **log in once** (run `claude` and complete the OAuth flow), and every later
+session — including separate dev tasks — reuses the token, which auto-refreshes. Set
+`CLAUDE_SANDBOX_HOME=<name>` to use an isolated home volume for a parallel/per-task sandbox (that
+volume needs its own one-time login). `ANTHROPIC_API_KEY` works as an alternative if you prefer
+not to log in interactively.
+
+### Running the gate and e2e inside the sandbox
+
+```sh
+npm run typecheck && npm run lint && npm test && npm run build   # gate
+CI=true bash docker/playwright-ci/run-playwright.sh              # e2e under Xvfb (CI parity)
+```
+
+The e2e path reuses the existing harness script — there is no separate npm script. `CI=true` is
+required so Playwright uses the non-blocking reporters (and writes `test-results/results.json`)
+instead of the auto-serving `html` report that would hang; the e2e Docker image sets this via
+`ENV`, but this general-purpose sandbox image does not. The container has its own Xvfb display and
+clipboard, so the clipboard-smoke project never touches your host clipboard. Results land in the
+bind-mounted `test-results/` and `playwright-report/` as usual; the known clipboard/tab-exporting
+flake is re-run in isolation with
+`CI=true xvfb-run -a npx playwright test --project=clipboard-smoke --retries=0`.
+```
+
+- [ ] **Step 2: Verify the doc renders and links resolve**
+
+Run:
+```bash
+grep -n "Claude Code sandbox" DEVELOPMENT.md
+ls docker/claude-sandbox/claude-sandbox.sh
+```
+Expected: the new heading is found, and the referenced script exists.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DEVELOPMENT.md
+git commit -m "docs: document the Claude Code sandbox in DEVELOPMENT.md"
+```
+
+---
+
+## Done
+
+The branch `claude-sandbox` now contains: the sandbox image, firewall, entrypoint, host launcher,
+and documentation, with the gate and e2e verified to run inside the container. Open a PR when ready
+(host step — push and `gh pr create`).
+```
+

--- a/docs/superpowers/plans/2026-06-20-claude-sandbox.md
+++ b/docs/superpowers/plans/2026-06-20-claude-sandbox.md
@@ -143,6 +143,13 @@ Replace the entire contents of `docker/claude-sandbox/init-firewall.sh` with:
 # --cap-add=NET_ADMIN). Allows: DNS, loopback, established connections, and a fixed set of
 # hosts (Anthropic API + auth, npm registry, GitHub). Everything else is dropped.
 #
+# PROVENANCE: derived from Anthropic's reference Claude Code devcontainer firewall:
+#   https://github.com/anthropics/claude-code/blob/main/.devcontainer/init-firewall.sh
+#   (derived 2026-06-20). This is a vendored copy — Anthropic does not distribute it as a
+#   package. To check for upstream improvements, diff this file against that URL periodically.
+#   Local deltas from upstream: simplified to IPv4-only ipset (no `aggregate` dependency) and a
+#   fixed hostname allowlist instead of reading domains from a config file.
+#
 # Resolution (dig/curl) runs BEFORE the default policy flips to DROP, so it relies on the
 # post-flush default-ACCEPT state. Order matters — do not move the policy lines up.
 set -euo pipefail

--- a/docs/superpowers/specs/2026-06-20-claude-sandbox-design.md
+++ b/docs/superpowers/specs/2026-06-20-claude-sandbox-design.md
@@ -1,0 +1,203 @@
+# Containerized Claude Code sandbox — design
+
+**Date:** 2026-06-20
+**Status:** Approved (pending implementation plan)
+
+## Goal
+
+Provide a reproducible, isolated container in which a Claude Code session can run with
+`claude --dangerously-skip-permissions` (full permissions, zero prompts) without risking the
+host machine, and in which the session can execute the **entire local gate plus the e2e suite**
+with no permission prompts and no nested Docker:
+
+```sh
+npm run typecheck && npm run lint && npm test && npm run build   # gate
+bash docker/playwright-ci/run-playwright.sh                      # e2e, in-place under Xvfb
+```
+
+`--dangerously-skip-permissions` removes all guardrails, so it must only ever run inside this
+isolated environment. The container protects the **host**; it does not protect the repo's git
+history or anything explicitly mounted in. Mount only what is needed; restrict outbound network
+to an allowlist.
+
+## Decisions (brainstormed and approved)
+
+1. **Packaging:** standalone Dockerfile + `docker run` helper script (not a VS Code devcontainer).
+   Mirrors the existing `docker/playwright-ci/` convention (Dockerfile + shell orchestrator),
+   is editor-agnostic, and gives a single command to drop into an isolated `claude` session.
+2. **Base image:** extend the same Playwright base used by the e2e harness
+   (`mcr.microsoft.com/playwright:v1.57.0-noble`). One container runs build + unit + e2e directly
+   under Xvfb — **no Docker-in-Docker, no host Docker socket mount.**
+3. **Claude Code auth:** persisted container-side login in a named volume (the host stores its
+   token in the macOS Keychain, so there is no credential file to bind-mount). Log in once; the
+   token persists across runs and auto-refreshes. `ANTHROPIC_API_KEY` is a documented alternative.
+4. **Network:** default-deny outbound egress with an iptables/ipset allowlist applied at container
+   start (Anthropic-reference `init-firewall.sh` pattern).
+5. **Repo availability:** bind-mount the working tree read-write at `/workspace` (including `.git`,
+   so the session can commit its own work). Deliberately do **not** mount other home-dir paths.
+
+## Why no nested Docker (the e2e insight)
+
+The repo's `npm run test:e2e:docker` builds and runs a Playwright container. Running that *inside*
+the sandbox would require Docker-in-Docker or bind-mounting `/var/run/docker.sock` — both hand the
+container control of the host Docker daemon, a trivial host-root escape that defeats the isolation
+goal. **Rejected.**
+
+Instead, because the sandbox image is built **from the same Playwright base** as the e2e harness,
+the sandbox container **is** the e2e environment. The session runs the suite **directly in its own
+container** via the same Xvfb invocation the harness uses today
+(`docker/playwright-ci/run-playwright.sh`). The container has its **own** Xvfb display and its
+**own** clipboard, so the `clipboard-smoke` project reads/writes the *container's* clipboard, never
+the host's. Full CI parity, one box.
+
+## Architecture
+
+### File layout
+
+```
+docker/claude-sandbox/
+  Dockerfile          # FROM mcr.microsoft.com/playwright:v1.57.0-noble
+  init-firewall.sh    # default-deny iptables/ipset egress allowlist
+  entrypoint.sh       # (root) run firewall → npm ci if needed → drop to non-root → exec cmd
+  claude-sandbox.sh   # host helper: docker build + docker run with caps/mounts/volumes
+```
+
+Plus a new **DEVELOPMENT.md** section documenting how to launch the sandbox and run the gate + e2e.
+
+### Image (`docker/claude-sandbox/Dockerfile`)
+
+- `FROM mcr.microsoft.com/playwright:v1.57.0-noble` — browsers, fonts, system libs, and Node baked
+  in. Keep aligned with `docker/playwright-ci/Dockerfile` when either is bumped.
+- Adds:
+  - `xsel` — clipboard support for the e2e clipboard-smoke project (same as the e2e image).
+  - `iptables`, `ipset`, `sudo`, `gosu` — firewall application + privilege drop.
+  - `git`, `gh` — version control and GitHub CLI for in-container work.
+  - `npm install -g @anthropic-ai/claude-code` — the Claude Code CLI.
+- Does **not** `COPY` repo source. The working tree is bind-mounted at runtime.
+- Sets `LABEL com.copy-as-markdown.image=claude-sandbox` so host-side image pruning can be scoped
+  to this project (mirrors the e2e harness label convention).
+- `ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]`.
+
+### The node_modules native-binary problem
+
+The host `node_modules/` contains **darwin-arm64** native binaries (esbuild, vitest, rollup,
+playwright) that cannot run on Linux. Therefore:
+
+- The repo bind-mount must **not** expose the host `node_modules/` to the container.
+- A **named volume** overlays `/workspace/node_modules`, shadowing whatever is in the bind-mounted
+  tree.
+- `entrypoint.sh` runs `npm ci` (Linux-native) into that volume **only when it is empty/stale**;
+  the volume persists across runs so this is a one-time cost.
+- Playwright browsers come from the base image (`/ms-playwright`, `PLAYWRIGHT_BROWSERS_PATH`
+  preset), so no browser download is needed.
+
+### Entrypoint flow (`entrypoint.sh`)
+
+Runs as **root** (required for iptables), in order:
+
+1. `init-firewall.sh` — apply the default-deny egress allowlist.
+2. Ensure deps: if `/workspace/node_modules` is empty, run `npm ci` as the non-root user.
+3. `exec gosu <non-root-user> "$@"` — drop privileges and run the requested command
+   (default: an interactive `bash`; or `claude` when passed).
+
+Running Claude as a **non-root** user is also why `--dangerously-skip-permissions` behaves cleanly.
+
+### Firewall (`init-firewall.sh`)
+
+Default-deny outbound, allow only:
+
+- **DNS** (so hostnames resolve).
+- **Anthropic API + Claude auth/login domains** (API calls + the one-time OAuth login flow).
+- **npm registry** (for the entrypoint `npm ci` and any in-task installs).
+- **GitHub**: `api.github.com`, `github.com`, `codeload.github.com` (gh CLI + git over HTTPS).
+- **Loopback / established connections.**
+
+Everything else is dropped. Built with `ipset` from resolved IP ranges, mirroring Anthropic's
+reference `init-firewall.sh`. Requires `--cap-add=NET_ADMIN --cap-add=NET_RAW` at `docker run`.
+
+### Host helper (`claude-sandbox.sh`)
+
+- Builds the image on first run (and on Dockerfile changes); tags it `copy-as-markdown-claude-sandbox`.
+- `docker run` flags:
+  - `--rm -it` — ephemeral container, interactive.
+  - `--cap-add=NET_ADMIN --cap-add=NET_RAW` — for the firewall.
+  - `--shm-size=1g` — Chromium shared memory **without** sharing the host IPC namespace
+    (chosen over the e2e harness's `--ipc=host` to keep the container's IPC isolated).
+  - `-v "$ROOT":/workspace` — working tree, read-write (includes `.git`).
+  - `-v <node_modules volume>:/workspace/node_modules` — Linux-native deps.
+  - `-v <home volume>:/home/<user>/.claude` — persisted Claude login + session state.
+- Default command drops into a shell; passing `claude` launches Claude Code directly.
+
+#### Auth volume scoping (login once)
+
+- **Default:** a single shared home volume `claude-sandbox-home`. Log in **once**; the token
+  persists and auto-refreshes, and **every** sandbox session — including separate dev tasks —
+  reuses it with **no re-login**.
+- **Per-task override:** `CLAUDE_SANDBOX_HOME=<name>` selects a dedicated home volume for an
+  isolated, parallel sandbox. That volume needs its own one-time login.
+- **Caveat:** two sandbox containers sharing the same home volume **simultaneously** also share
+  `~/.claude` session/history state and can mildly contend (auth is unaffected). Sequential
+  sessions are fine; use a per-task volume for true parallel isolation.
+
+### In-container e2e: reuse `run-playwright.sh` (no new npm script)
+
+No new npm script is added — the package.json script list stays as-is. The in-container e2e path
+reuses the **existing** canonical Xvfb wrapper that the e2e harness and CI already use:
+
+```sh
+bash docker/playwright-ci/run-playwright.sh
+```
+
+Because the working tree is bind-mounted at `/workspace`, this script is present at
+`/workspace/docker/playwright-ci/run-playwright.sh`. It is the same script the e2e Docker image
+runs as its ENTRYPOINT (`xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension RANDR"
+npm run test:e2e`), so there is a single source of truth for the Xvfb invocation and the sandbox
+gets full CI parity for free.
+
+The known clipboard/tab-exporting flake is re-run in isolation in-container, e.g.
+`playwright test --project=clipboard-smoke --retries=0`.
+
+Test artifacts (`test-results/`, `playwright-report/`) land in the bind-mounted tree, so they are
+readable on the host exactly as today.
+
+## Mounts: least privilege
+
+**Mounted:**
+
+| Source | Target | Mode | Purpose |
+|--------|--------|------|---------|
+| repo root | `/workspace` | rw | live working tree incl. `.git` |
+| named volume | `/workspace/node_modules` | rw | Linux-native deps |
+| named volume (`claude-sandbox-home` or per-task) | `~/.claude` | rw | persisted login + session state |
+
+**Deliberately NOT mounted:** `~/.ssh`, `~/.aws`, `~/.npmrc`, host `~/.gitconfig` secrets, shell
+history, the macOS Keychain, or any other home-dir path.
+
+## Security properties
+
+- `--dangerously-skip-permissions` runs only inside the container; host filesystem is unreachable
+  except the explicit mounts.
+- No Docker socket, no Docker-in-Docker: the container cannot control the host daemon.
+- Default-deny egress limits data exfiltration to the allowlisted hosts.
+- Host Claude credentials (Keychain) are never exposed; the sandbox has its own login.
+- Acknowledged residual risk: the working tree (including `.git` history) is read-write and
+  reachable by the session — this is the accepted tradeoff for letting Claude edit and commit.
+
+## Testing / verification
+
+- Image builds successfully.
+- Inside the container, the full gate passes:
+  `npm run typecheck && npm run lint && npm test && npm run build`.
+- Inside the container, `bash docker/playwright-ci/run-playwright.sh` runs the Playwright suite (both projects) to
+  completion; the clipboard-smoke project uses the container clipboard, not the host's.
+- Firewall: an allowlisted host (e.g. the npm registry) is reachable; a non-allowlisted host is
+  blocked.
+- Auth: after a one-time in-container login, a fresh `docker run` reuses the token with no
+  re-login.
+
+## Out of scope
+
+- VS Code devcontainer integration (`.devcontainer/`).
+- Fixing the broken Python/pytest Firefox e2e suite (`e2e_test/`).
+- Changing the existing `docker/playwright-ci/` harness (the sandbox reuses its base image and
+  Xvfb pattern but does not replace it).

--- a/docs/superpowers/specs/2026-06-20-claude-sandbox-design.md
+++ b/docs/superpowers/specs/2026-06-20-claude-sandbox-design.md
@@ -12,7 +12,7 @@ with no permission prompts and no nested Docker:
 
 ```sh
 npm run typecheck && npm run lint && npm test && npm run build   # gate
-bash docker/playwright-ci/run-playwright.sh                      # e2e, in-place under Xvfb
+CI=true bash docker/playwright-ci/run-playwright.sh              # e2e, in-place under Xvfb
 ```
 
 `--dangerously-skip-permissions` removes all guardrails, so it must only ever run inside this
@@ -152,7 +152,10 @@ Because the working tree is bind-mounted at `/workspace`, this script is present
 `/workspace/docker/playwright-ci/run-playwright.sh`. It is the same script the e2e Docker image
 runs as its ENTRYPOINT (`xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension RANDR"
 npm run test:e2e`), so there is a single source of truth for the Xvfb invocation and the sandbox
-gets full CI parity for free.
+gets full CI parity for free. The command is run with `CI=true` so Playwright selects the
+non-blocking reporters (and writes `test-results/results.json`) rather than the auto-serving `html`
+report that would hang — the e2e Docker image sets this via `ENV`, but the general-purpose sandbox
+image does not.
 
 The known clipboard/tab-exporting flake is re-run in isolation in-container, e.g.
 `playwright test --project=clipboard-smoke --retries=0`.

--- a/test/build/global-setup.ts
+++ b/test/build/global-setup.ts
@@ -1,0 +1,18 @@
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// Build both extension targets ONCE before the whole suite runs.
+//
+// The build tests under test/build/ assert against chrome/dist and firefox-mv3/dist.
+// scripts/build.js destructively cleans the target's dist (`rm -rf <target>/dist`) before
+// rebuilding, so when each test rebuilt in its own parallel vitest worker they wiped each
+// other's in-flight output — a race that is benign on fast native FS but reliably corrupts on
+// slower bind-mounted (container) FS. Building once here, before any worker starts, removes both
+// the race and the redundant repeat builds.
+export default function setup(): void {
+  execSync('node scripts/build.js chrome', { cwd: root, stdio: 'inherit' });
+  execSync('node scripts/build.js firefox-mv3', { cwd: root, stdio: 'inherit' });
+}

--- a/test/build/no-polyfill-in-firefox.test.ts
+++ b/test/build/no-polyfill-in-firefox.test.ts
@@ -1,8 +1,7 @@
-import { execSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.join(here, '..', '..');
@@ -43,12 +42,8 @@ function jsFiles(distDir: string): string[] {
   return out;
 }
 
+// Both extension targets are built once by test/build/global-setup.ts before the suite runs.
 describe('webextension-polyfill ships to chrome only', () => {
-  beforeAll(() => {
-    execSync('node scripts/build.js firefox-mv3', { cwd: root, stdio: 'inherit' });
-    execSync('node scripts/build.js chrome', { cwd: root, stdio: 'inherit' });
-  }, 180_000);
-
   // --- Firefox: fully absent ---
   it('does not ship browser-polyfill.js to firefox vendor', () => {
     expect(existsSync(path.join(firefoxDist, 'vendor', 'browser-polyfill.js'))).toBe(false);

--- a/test/build/no-turndown-in-chrome-background.test.ts
+++ b/test/build/no-turndown-in-chrome-background.test.ts
@@ -1,19 +1,14 @@
-import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const root = path.join(here, '..', '..');
 const bundlePath = path.join(root, 'chrome', 'dist', 'background.js');
 
+// Both extension targets are built once by test/build/global-setup.ts before the suite runs.
 describe('chrome background bundle', () => {
-  beforeAll(() => {
-    // Build the Chrome target so the assertion runs against fresh output.
-    execSync('node scripts/build.js chrome', { cwd: root, stdio: 'inherit' });
-  }, 120_000);
-
   it('does not bundle Turndown (DOM-only) code', () => {
     const source = readFileSync(bundlePath, 'utf8');
     expect(source).not.toMatch(/TurndownService/);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,11 @@ const polyfillAlias = [
 
 export default defineConfig({
   test: {
+    // Build both extension targets once before the suite. The build tests under test/build/
+    // read chrome/dist and firefox-mv3/dist; scripts/build.js destructively cleans each dist,
+    // so per-test rebuilds in parallel workers raced and corrupted each other's output. See
+    // test/build/global-setup.ts.
+    globalSetup: ['./test/build/global-setup.ts'],
     projects: [
       {
         resolve: { alias: polyfillAlias },


### PR DESCRIPTION
## Summary

Isolated Claude sandbox that allows all permissions in the container so I can execute a Superpowers implementation plan without intervention.

Arguably this is yolo coding but the things is i spent a lot of time doing pre-coding design and planning with Superpowers, and don't want Claude Code to ask for permission to execute a step-by-step plan. Blind approval on host machine is not better than full permission in a lockdown sandbox.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)


## AI Disclosure

<!-- Check one. Be honest. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [x] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [ ] I did not use any coding agent to create this patch. I am responsible for all the code I wrote.
