### PR TITLE
Upgrade playwright to resolve Node 24 incompatibility

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,7 +41,7 @@ jobs:
     needs: build
     timeout-minutes: 10
     container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
+      image: mcr.microsoft.com/playwright:v1.61.0-noble
     steps:
       - uses: actions/checkout@v6
       - name: Install clipboard dependencies

--- a/docker/playwright-ci/Dockerfile
+++ b/docker/playwright-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.57.0-noble
+FROM mcr.microsoft.com/playwright:v1.61.0-noble
 
 # Label so the host wrapper (docker/playwright-ci/docker-e2e.sh) can prune ONLY the
 # images this project's rebuilds orphan, leaving other projects' dangling images alone.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@antfu/eslint-config": "^5.4.1",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.61.0",
         "@truto/turndown-plugin-gfm": "^1.0.2",
         "@types/chrome": "^0.1.31",
         "@types/firefox-webext-browser": "^143.0.0",
@@ -27,7 +27,7 @@
         "eslint": "^9.37.0",
         "eslint-config-prettier": "^10.1.8",
         "http-server": "^14.1.1",
-        "playwright": "^1.57.0",
+        "playwright": "^1.61.0",
         "tsx": "^4.20.6",
         "turndown": "^7.1.3",
         "typescript": "^5.4.0",
@@ -1110,13 +1110,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6181,13 +6181,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6200,9 +6200,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "^5.4.1",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.61.0",
     "@truto/turndown-plugin-gfm": "^1.0.2",
     "@types/chrome": "^0.1.31",
     "@types/firefox-webext-browser": "^143.0.0",
@@ -55,7 +55,7 @@
     "eslint": "^9.37.0",
     "eslint-config-prettier": "^10.1.8",
     "http-server": "^14.1.1",
-    "playwright": "^1.57.0",
+    "playwright": "^1.61.0",
     "tsx": "^4.20.6",
     "turndown": "^7.1.3",
     "typescript": "^5.4.0",


### PR DESCRIPTION
## Summary

Download hangs on Node.js 24 + Ubuntu 24.04 + Playwright v1.57.0

Upgrade to >= 1.61.0 to resolve this issue.

CI does not have this issue because it's using a pre-built playwright image that comes with browsers already. This issue only happens on Ubuntu 24.04 where running `npx playwright install` .

Test target becomes Chrome 149 but that's fine.

https://github.com/microsoft/playwright/issues/40724

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)


## AI Disclosure

<!-- Check one. Be honest. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [ ] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [ ] I did not use any coding agent to create this patch. I am responsible for all the code I wrote.
