### PR TITLE
Run Selenium  E2E test suite in Docker

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -88,7 +88,7 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y firefox xvfb xsel
+        run: sudo apt-get update && sudo apt-get install -y firefox xvfb xsel xdotool
       - name: Use Python
         uses: actions/setup-python@v6
         with:

--- a/docker/selenium-ci/Dockerfile
+++ b/docker/selenium-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM python:3.14-slim-bookworm
 
 # Label so the host wrapper can prune ONLY images this project's rebuilds orphan,
 # leaving other projects' dangling images alone.
@@ -13,23 +13,33 @@ WORKDIR /workspace
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
       ca-certificates \
-      gnupg \
-      software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Firefox from Mozilla APT (bypasses Ubuntu 24.04's snap-transition package)
-RUN install -d -m 0755 /etc/apt/keyrings \
-    && curl -fsSL https://packages.mozilla.org/apt/repo-signing-key.gpg \
-       -o /etc/apt/keyrings/packages.mozilla.org.asc \
-    && echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" \
-       > /etc/apt/sources.list.d/mozilla.list \
-    && printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' \
-       > /etc/apt/preferences.d/mozilla \
-    && apt-get update && apt-get install -y --no-install-recommends firefox \
+# --- Firefox ESR (Debian bookworm ships firefox-esr in main; no snap) -------
+#
+# We use firefox-esr rather than release Firefox (packages.mozilla.org/apt)
+# because it ships cleanly in Debian's repos with no extra configuration.
+#
+# Trade-off: ESR lags the release channel by ~3 major versions. As of this
+# writing, firefox-esr is ~140 and the manifest.json requires_min is 139, so
+# ESR is a valid test target. If requires_min is ever bumped past the current
+# ESR major version, switch to Mozilla APT release Firefox:
+#
+#   install -d -m 0755 /etc/apt/keyrings
+#   curl -fsSL https://packages.mozilla.org/apt/repo-signing-key.gpg \
+#        -o /etc/apt/keyrings/packages.mozilla.org.asc
+#   echo "deb [signed-by=...] https://packages.mozilla.org/apt mozilla main" \
+#        > /etc/apt/sources.list.d/mozilla.list
+#   printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' \
+#        > /etc/apt/preferences.d/mozilla
+#   apt-get update && apt-get install -y firefox
+#
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      firefox-esr \
     && rm -rf /var/lib/apt/lists/*
 
 # --- geckodriver (arch-aware binary from GitHub releases) -------------------
-# firefox-geckodriver is not available on arm64; download the appropriate binary.
+# Not packaged in Debian; download the appropriate binary for the build arch.
 ARG GECKODRIVER_VERSION=0.35.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
@@ -51,22 +61,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       xdotool \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Python 3.14 from deadsnakes PPA ----------------------------------------
-RUN add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update && apt-get install -y --no-install-recommends \
-      python3.14 \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3.14
-
-# --- Node.js 22 (lts/krypton) via NodeSource --------------------------------
+# --- Node.js 22 (lts/jod) via NodeSource ------------------------------------
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Python dependencies ----------------------------------------------------
-# pyautogui pulls in python-xlib / mouseinfo automatically.
 COPY requirements.txt ./
-RUN python3.14 -m pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # --- Node dependencies (cached layer) ----------------------------------------
 COPY package.json package-lock.json* ./

--- a/docker/selenium-ci/Dockerfile
+++ b/docker/selenium-ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.14-slim
 
-# Label so the host wrapper can prune ONLY images this project's rebuilds orphan,
-# leaving other projects' dangling images alone.
+# The label lets docker-e2e.sh prune only images orphaned by this project's
+# own rebuilds, without touching dangling images from other projects.
 LABEL com.copy-as-markdown.image=selenium-e2e
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -9,26 +9,21 @@ ENV CI=true
 
 WORKDIR /workspace
 
-# --- Base system tools ------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl \
       ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Firefox ESR (Debian bookworm ships firefox-esr in main; no snap) -------
-#
-# We use firefox-esr rather than release Firefox (packages.mozilla.org/apt)
-# because it ships cleanly in Debian's repos with no extra configuration.
-#
-# Trade-off: ESR lags the release channel by ~3 major versions. As of this
-# writing, firefox-esr is ~140 and the manifest.json requires_min is 139, so
-# ESR is a valid test target. If requires_min is ever bumped past the current
-# ESR major version, switch to Mozilla APT release Firefox:
+# firefox-esr ships in Debian's main repo and satisfies manifest.json's
+# requires_min (139) as long as the current ESR major stays above it (140 as
+# of this writing). If requires_min is ever bumped past the current ESR major,
+# switch to release Firefox via Mozilla APT instead:
 #
 #   install -d -m 0755 /etc/apt/keyrings
 #   curl -fsSL https://packages.mozilla.org/apt/repo-signing-key.gpg \
 #        -o /etc/apt/keyrings/packages.mozilla.org.asc
-#   echo "deb [signed-by=...] https://packages.mozilla.org/apt mozilla main" \
+#   echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] \
+#        https://packages.mozilla.org/apt mozilla main" \
 #        > /etc/apt/sources.list.d/mozilla.list
 #   printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' \
 #        > /etc/apt/preferences.d/mozilla
@@ -38,8 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       firefox-esr \
     && rm -rf /var/lib/apt/lists/*
 
-# --- geckodriver (arch-aware binary from GitHub releases) -------------------
-# Not packaged in Debian; download the appropriate binary for the build arch.
+# geckodriver is not packaged in Debian; download the release binary directly.
 ARG GECKODRIVER_VERSION=0.35.0
 RUN set -eux; \
     ARCH="$(uname -m)"; \
@@ -53,7 +47,8 @@ RUN set -eux; \
       | tar xz -C /usr/local/bin/ \
     && chmod +x /usr/local/bin/geckodriver
 
-# --- xvfb, xauth, xsel, xdotool (virtual display + real clipboard + key injection) --
+# xvfb: headless display   xauth: required by xvfb-run   xsel: real clipboard
+# xdotool: X11 key injection for extension keyboard shortcuts
 RUN apt-get update && apt-get install -y --no-install-recommends \
       xvfb \
       xauth \
@@ -61,21 +56,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       xdotool \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Node.js 22 (lts/jod) via NodeSource ------------------------------------
+# Node.js 22 (lts/jod) — not in Debian's repos at this version
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Python dependencies ----------------------------------------------------
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# --- Node dependencies (cached layer) ----------------------------------------
+# Separate COPY so the npm layer is cached independently of source changes
 COPY package.json package-lock.json* ./
 RUN mkdir -p src/vendor/ dist/ \
     && npm ci
 
-# --- Extension source -------------------------------------------------------
 COPY . .
 
 COPY docker/selenium-ci/run-selenium.sh /usr/local/bin/run-selenium.sh

--- a/docker/selenium-ci/Dockerfile
+++ b/docker/selenium-ci/Dockerfile
@@ -56,8 +56,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       xdotool \
     && rm -rf /var/lib/apt/lists/*
 
-# Node.js 22 (lts/jod) — not in Debian's repos at this version
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+# Node.js 24 — not in Debian's repos at this version
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/selenium-ci/Dockerfile
+++ b/docker/selenium-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-bookworm
+FROM python:3.14-slim
 
 # Label so the host wrapper can prune ONLY images this project's rebuilds orphan,
 # leaving other projects' dangling images alone.

--- a/docker/selenium-ci/Dockerfile
+++ b/docker/selenium-ci/Dockerfile
@@ -43,22 +43,18 @@ RUN set -eux; \
       | tar xz -C /usr/local/bin/ \
     && chmod +x /usr/local/bin/geckodriver
 
-# --- xvfb, xauth, xsel (virtual display + real clipboard) ------------------
+# --- xvfb, xauth, xsel, xdotool (virtual display + real clipboard + key injection) --
 RUN apt-get update && apt-get install -y --no-install-recommends \
       xvfb \
       xauth \
       xsel \
+      xdotool \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Python 3.14 from deadsnakes PPA (includes -tk variant) -----------------
-# python3.14-tk provides tkinter, required by mouseinfo (a pyautogui dependency).
-# python3.14-dev provides headers needed to build pyautogui's C-extension deps.
+# --- Python 3.14 from deadsnakes PPA ----------------------------------------
 RUN add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update && apt-get install -y --no-install-recommends \
       python3.14 \
-      python3.14-dev \
-      python3.14-tk \
-      build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3.14
 

--- a/docker/selenium-ci/Dockerfile
+++ b/docker/selenium-ci/Dockerfile
@@ -1,0 +1,86 @@
+FROM ubuntu:24.04
+
+# Label so the host wrapper can prune ONLY images this project's rebuilds orphan,
+# leaving other projects' dangling images alone.
+LABEL com.copy-as-markdown.image=selenium-e2e
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CI=true
+
+WORKDIR /workspace
+
+# --- Base system tools ------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl \
+      ca-certificates \
+      gnupg \
+      software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Firefox from Mozilla APT (bypasses Ubuntu 24.04's snap-transition package)
+RUN install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://packages.mozilla.org/apt/repo-signing-key.gpg \
+       -o /etc/apt/keyrings/packages.mozilla.org.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" \
+       > /etc/apt/sources.list.d/mozilla.list \
+    && printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' \
+       > /etc/apt/preferences.d/mozilla \
+    && apt-get update && apt-get install -y --no-install-recommends firefox \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- geckodriver (arch-aware binary from GitHub releases) -------------------
+# firefox-geckodriver is not available on arm64; download the appropriate binary.
+ARG GECKODRIVER_VERSION=0.35.0
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    case "$ARCH" in \
+      x86_64)  GD_ARCH="linux64" ;; \
+      aarch64) GD_ARCH="linux-aarch64" ;; \
+      *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
+    esac; \
+    curl -fsSL \
+      "https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-${GD_ARCH}.tar.gz" \
+      | tar xz -C /usr/local/bin/ \
+    && chmod +x /usr/local/bin/geckodriver
+
+# --- xvfb, xauth, xsel (virtual display + real clipboard) ------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      xvfb \
+      xauth \
+      xsel \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Python 3.14 from deadsnakes PPA (includes -tk variant) -----------------
+# python3.14-tk provides tkinter, required by mouseinfo (a pyautogui dependency).
+# python3.14-dev provides headers needed to build pyautogui's C-extension deps.
+RUN add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+      python3.14 \
+      python3.14-dev \
+      python3.14-tk \
+      build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3.14
+
+# --- Node.js 22 (lts/krypton) via NodeSource --------------------------------
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Python dependencies ----------------------------------------------------
+# pyautogui pulls in python-xlib / mouseinfo automatically.
+COPY requirements.txt ./
+RUN python3.14 -m pip install --no-cache-dir -r requirements.txt
+
+# --- Node dependencies (cached layer) ----------------------------------------
+COPY package.json package-lock.json* ./
+RUN mkdir -p src/vendor/ dist/ \
+    && npm ci
+
+# --- Extension source -------------------------------------------------------
+COPY . .
+
+COPY docker/selenium-ci/run-selenium.sh /usr/local/bin/run-selenium.sh
+RUN chmod +x /usr/local/bin/run-selenium.sh
+
+ENTRYPOINT ["/usr/local/bin/run-selenium.sh"]

--- a/docker/selenium-ci/docker-e2e.sh
+++ b/docker/selenium-ci/docker-e2e.sh
@@ -11,6 +11,11 @@
 # Any extra arguments are forwarded to `docker run` (after the image name).
 set -uo pipefail
 
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "error: test:e2e:selenium:docker is Linux-only (uses xdotool + AT-SPI)" >&2
+    exit 1
+fi
+
 IMAGE=copy-as-markdown-selenium
 LABEL=com.copy-as-markdown.image=selenium-e2e
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/docker/selenium-ci/docker-e2e.sh
+++ b/docker/selenium-ci/docker-e2e.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Host-side orchestrator for the Dockerized Selenium Firefox e2e suite.
+#
+# Builds the image and runs the suite, then removes the image build that this run
+# superseded. Re-tagging on every `docker build -t copy-as-markdown-selenium`
+# orphans the previously-tagged image as a dangling <none> image; left unchecked
+# these pile up. Pruning is scoped by our own LABEL so other projects' dangling
+# images on the machine are never touched.
+#
+# Any extra arguments are forwarded to `docker run` (after the image name).
+set -uo pipefail
+
+IMAGE=copy-as-markdown-selenium
+LABEL=com.copy-as-markdown.image=selenium-e2e
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+docker build -t "$IMAGE" -f "$ROOT/docker/selenium-ci/Dockerfile" "$ROOT" || exit $?
+
+docker run --rm --ipc=host -e CI=true \
+  -v "$ROOT/test-results:/workspace/test-results" \
+  "$IMAGE" "$@"
+code=$?
+
+# Remove dangling images orphaned by this project's previous builds (label-scoped).
+docker image prune -f --filter "label=$LABEL" >/dev/null 2>&1 || true
+
+exit "$code"

--- a/docker/selenium-ci/run-selenium.sh
+++ b/docker/selenium-ci/run-selenium.sh
@@ -9,7 +9,7 @@ npm run test:e2e:build
 echo "[docker] Starting Selenium Firefox suite via Xvfb..."
 
 xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension RANDR" \
-  python3.14 -m pytest e2e_test/ -v
+  python -m pytest e2e_test/ -v
 
 exit_code=$?
 echo "[docker] Selenium suite finished with exit code: $exit_code"

--- a/docker/selenium-ci/run-selenium.sh
+++ b/docker/selenium-ci/run-selenium.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export FORCE_COLOR=1
+
+echo "[docker] Building test extensions..."
+npm run test:e2e:build
+
+echo "[docker] Starting Selenium Firefox suite via Xvfb..."
+
+xvfb-run -a --server-args="-screen 0 1280x720x24 -ac +extension RANDR" \
+  python3.14 -m pytest e2e_test/ -v
+
+exit_code=$?
+echo "[docker] Selenium suite finished with exit code: $exit_code"
+exit $exit_code

--- a/e2e_test/keyboard_shortcuts.py
+++ b/e2e_test/keyboard_shortcuts.py
@@ -1,4 +1,4 @@
-import pyautogui
+import subprocess
 from dataclasses import dataclass
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
@@ -10,9 +10,7 @@ class Shortcut:
     keystroke: str
 
     def press(self):
-        with pyautogui.hold('shift'):
-            with pyautogui.hold('alt'):
-                pyautogui.press(self.keystroke)
+        subprocess.run(['xdotool', 'key', f'alt+shift+{self.keystroke}'], check=True)
 
     def run_action_chain(self, actions: ActionChains):
         return actions.key_down(Keys.ALT).key_down(Keys.SHIFT).send_keys(self.keystroke).key_up(Keys.SHIFT).key_up(Keys.ALT)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e:debug": "npm run test:e2e:build && playwright test --debug",
     "test:e2e:docker": "bash docker/playwright-ci/docker-e2e.sh",
     "test:e2e:selenium": "npm run test:e2e:build && xvfb-run -a --server-args=\"-screen 0 1280x720x24 -ac +extension RANDR\" pytest e2e_test/ -v",
+    "test:e2e:selenium:docker": "bash docker/selenium-ci/docker-e2e.sh",
     "bump-version": "node scripts/bump-version.js",
     "typecheck": "tsc",
     "build": "npm run build-chrome && npm run build-firefox-mv3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 selenium
 pytest
-pyautogui
 pyperclip


### PR DESCRIPTION
## Summary

Run Selenium E2E test suite in Docker so I can reliably run on macOS.

The Selenium E2E test suite is targeting Firefox only, covering hot paths that require OS tools, such as keyboard shortcuts, system clipboard, and (in the future) context menu.

Also replaced pyautogui with xdotool because this test suite is targeting Linux only. No macOS compatibility is required.

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)


## AI Disclosure

<!-- Check one. Be honest. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [x] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [ ] I did not use any coding agent to create this patch. I am responsible for all the code I wrote.
