### PR TITLE
Move link-text escaping to an Advanced page under Others

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -34,7 +34,7 @@ The extension is built with **esbuild**, once per target (`chrome` and `firefox-
    import them — there is no `src/vendor` snapshot and no `postinstall` copy step.
 
 The entry points are listed in `entryPointsFor()` in `scripts/lib/build-extension.js`: `background`
-+ the six UI page scripts for both targets, plus `offscreen` for Chrome only (Firefox has no
++ the seven UI page scripts for both targets, plus `offscreen` for Chrome only (Firefox has no
 offscreen API).
 
 ## Compile-time target flag (`BUILD_TARGET`)

--- a/scripts/lib/build-extension.js
+++ b/scripts/lib/build-extension.js
@@ -14,6 +14,7 @@ const sharedEntries = [
   'src/ui/permissions.ts',
   'src/ui/custom-format.ts',
   'src/ui/menu-commands.ts',
+  'src/ui/advanced.ts',
 ];
 
 function entryPointsFor(target) {

--- a/src/lib/markdown-settings.ts
+++ b/src/lib/markdown-settings.ts
@@ -12,11 +12,16 @@ export interface MarkdownSettings {
   multipleLinks: MultipleLinksMarkdownSettings;
 }
 
+/** The keys owned by an output context — everything the Markdown Style page presents. */
+export const contextMarkdownSettingsKeys: string[] = [
+  ...SelectionSettings.keys,
+  ...MultipleLinksSettings.keys,
+];
+
 /** Every storage key whose change should re-read the settings above. */
 export const markdownSettingsKeys: string[] = [
   ...Settings.keys,
-  ...SelectionSettings.keys,
-  ...MultipleLinksSettings.keys,
+  ...contextMarkdownSettingsKeys,
 ];
 
 /**
@@ -54,11 +59,14 @@ export async function setSharedBulletListMarker(marker: BulletListMarker): Promi
 }
 
 /**
- * Restore every Markdown setting the combined page owns, in a single removal.
+ * Restore every Markdown setting the Markdown Style page owns, in a single removal.
  *
  * Transitional for the same reason as `setSharedBulletListMarker`: one visible
  * "Restore to Default" button must not be able to reset some contexts and not
  * others. Per-page resets replace this.
+ *
+ * Link-text escaping is deliberately absent: the Advanced page owns it and
+ * resets it on its own, so neither reset can silently undo the other.
  *
  * Legacy keys go too. A migration whose cleanup failed leaves them behind, and
  * a reset that spared them would be undone by the next startup re-migrating
@@ -66,7 +74,7 @@ export async function setSharedBulletListMarker(marker: BulletListMarker): Promi
  */
 export async function resetMarkdownSettings(): Promise<void> {
   await browser.storage.sync.remove([
-    ...markdownSettingsKeys,
+    ...contextMarkdownSettingsKeys,
     ...Object.values(LegacyMarkdownSettingKeys),
   ]);
 }

--- a/src/static/about.html
+++ b/src/static/about.html
@@ -18,7 +18,6 @@
         <p class="menu-label">General</p>
         <ul class="menu-list">
           <li><a href="options.html">Markdown Style</a></li>
-          <li><a href="options-permissions.html">Permissions</a></li>
           <p class="menu-label">Formats</p>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
@@ -44,6 +43,8 @@
         <p class="menu-label">Others</p>
         <ul class="menu-list">
           <li><a href="menu-commands.html">Menu Commands</a></li>
+          <li><a href="advanced.html">Advanced</a></li>
+          <li><a href="options-permissions.html">Permissions</a></li>
           <li><a href="custom-format-help.html">Help & Examples</a></li>
           <li><a class="is-active" href="about.html">About</a></li>
         </ul>

--- a/src/static/advanced.html
+++ b/src/static/advanced.html
@@ -9,7 +9,7 @@
 <body>
 <div class="container section is-max-desktop">
   <h1 class="title">Copy as Markdown</h1>
-  <div id="flash-error" class="notification is-danger is-hidden">
+  <div id="flash-error" data-testid="flash-error" class="notification is-danger is-hidden">
     <p></p>
   </div>
   <div class="columns">
@@ -30,7 +30,7 @@
             </ul>
           </li>
           <li>
-            <a class="is-active" href="single-link.html">Single Link</a>
+            <a href="single-link.html">Single Link</a>
             <ul class="menu-list" data-menu-custom-format-context="single-link">
               <li><a data-menu-custom-format-slot="1" href="custom-format.html?context=single-link&slot=1">Custom Format 1</a></li>
               <li><a data-menu-custom-format-slot="2" href="custom-format.html?context=single-link&slot=2">Custom Format 2</a></li>
@@ -43,7 +43,7 @@
         <p class="menu-label">Others</p>
         <ul class="menu-list">
           <li><a href="menu-commands.html">Menu Commands</a></li>
-          <li><a href="advanced.html">Advanced</a></li>
+          <li><a class="is-active" href="advanced.html">Advanced</a></li>
           <li><a href="options-permissions.html">Permissions</a></li>
           <li><a href="custom-format-help.html">Help & Examples</a></li>
           <li><a href="about.html">About</a></li>
@@ -52,15 +52,35 @@
     </div>
     <div class="column">
       <div class="box content">
-        <h2 class="title is-3">Format - Single Link</h2>
-        <p>
-          Single Link has no settings of its own yet. Its custom formats are in the menu on the left,
-          and which commands appear in menus is on the
-          <a href="menu-commands.html">Menu Commands</a> page.
-        </p>
+        <h2 class="title is-3">Advanced</h2>
+
+        <form id="form-link-text-always-escape-brackets" class="field">
+          <label class="label">Escaping</label>
+          <div class="control">
+            <label class="checkbox"><input type="checkbox" name="enabled"/> Always escape brackets in link text (<code>[]</code>
+              becomes <code>\[\]</code>)</label>
+          </div>
+          <p class="help">
+            CommonMark allows balanced brackets <code>[]</code> in link text
+            (e.g. <code>[[JIRA-123] My Project](https://link/)</code>).
+            If your Markdown processor does not support this use case, you can enable this feature
+            so that Copy as Markdown always escape brackets in the link text.
+          </p>
+          <p class="help">
+            This applies to generated-link workflows — Single Link, Multiple Links, and custom formats —
+            and does not affect Copy Selection as Markdown, which escapes according to its own conversion rules.
+          </p>
+        </form>
       </div>
+      <div class="field is-grouped">
+        <div class="control">
+          <button id="reset" data-testid="reset-advanced" type="button" class="button is-outlined is-danger">Restore Advanced Defaults</button>
+        </div>
+      </div>
+      <p class="help">Restores link-text escaping to its default. Formatting, menu-visibility, and permission settings are left untouched.</p>
     </div>
   </div>
 </div>
+<script src="../ui/advanced.js" type="module"></script>
 </body>
 </html>

--- a/src/static/custom-format-help.html
+++ b/src/static/custom-format-help.html
@@ -18,7 +18,6 @@
         <p class="menu-label">General</p>
         <ul class="menu-list">
           <li><a href="options.html">Markdown Style</a></li>
-          <li><a href="options-permissions.html">Permissions</a></li>
           <p class="menu-label">Formats</p>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
@@ -44,6 +43,8 @@
         <p class="menu-label">Others</p>
         <ul class="menu-list">
           <li><a href="menu-commands.html">Menu Commands</a></li>
+          <li><a href="advanced.html">Advanced</a></li>
+          <li><a href="options-permissions.html">Permissions</a></li>
           <li><a class="is-active" href="custom-format-help.html">Help & Examples</a></li>
           <li><a href="about.html">About</a></li>
         </ul>

--- a/src/static/custom-format.html
+++ b/src/static/custom-format.html
@@ -16,7 +16,6 @@
         <p class="menu-label">General</p>
         <ul class="menu-list">
           <li><a href="options.html">Markdown Style</a></li>
-          <li><a href="options-permissions.html">Permissions</a></li>
           <p class="menu-label">Formats</p>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
@@ -42,6 +41,8 @@
         <p class="menu-label">Others</p>
         <ul class="menu-list">
           <li><a href="menu-commands.html">Menu Commands</a></li>
+          <li><a href="advanced.html">Advanced</a></li>
+          <li><a href="options-permissions.html">Permissions</a></li>
           <li><a href="custom-format-help.html">Help & Examples</a></li>
           <li><a href="about.html">About</a></li>
         </ul>

--- a/src/static/menu-commands.html
+++ b/src/static/menu-commands.html
@@ -18,7 +18,6 @@
         <p class="menu-label">General</p>
         <ul class="menu-list">
           <li><a href="options.html">Markdown Style</a></li>
-          <li><a href="options-permissions.html">Permissions</a></li>
           <p class="menu-label">Formats</p>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
@@ -44,6 +43,8 @@
         <p class="menu-label">Others</p>
         <ul class="menu-list">
           <li><a class="is-active" href="menu-commands.html">Menu Commands</a></li>
+          <li><a href="advanced.html">Advanced</a></li>
+          <li><a href="options-permissions.html">Permissions</a></li>
           <li><a href="custom-format-help.html">Help & Examples</a></li>
           <li><a href="about.html">About</a></li>
         </ul>

--- a/src/static/multiple-links.html
+++ b/src/static/multiple-links.html
@@ -18,7 +18,6 @@
         <p class="menu-label">General</p>
         <ul class="menu-list">
           <li><a href="options.html">Markdown Style</a></li>
-          <li><a href="options-permissions.html">Permissions</a></li>
           <p class="menu-label">Formats</p>
           <li>
             <a class="is-active" href="multiple-links.html">Multiple Links</a>
@@ -44,6 +43,8 @@
         <p class="menu-label">Others</p>
         <ul class="menu-list">
           <li><a href="menu-commands.html">Menu Commands</a></li>
+          <li><a href="advanced.html">Advanced</a></li>
+          <li><a href="options-permissions.html">Permissions</a></li>
           <li><a href="custom-format-help.html">Help & Examples</a></li>
           <li><a href="about.html">About</a></li>
         </ul>

--- a/src/static/options-permissions.html
+++ b/src/static/options-permissions.html
@@ -18,7 +18,6 @@
         <p class="menu-label">General</p>
         <ul class="menu-list">
           <li><a href="options.html">Markdown Style</a></li>
-          <li><a class="is-active" href="options-permissions.html">Permissions</a></li>
           <p class="menu-label">Formats</p>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
@@ -44,6 +43,8 @@
         <p class="menu-label">Others</p>
         <ul class="menu-list">
           <li><a href="menu-commands.html">Menu Commands</a></li>
+          <li><a href="advanced.html">Advanced</a></li>
+          <li><a class="is-active" href="options-permissions.html">Permissions</a></li>
           <li><a href="custom-format-help.html">Help & Examples</a></li>
           <li><a href="about.html">About</a></li>
         </ul>

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -117,11 +117,6 @@
             Please note that this option does not affect indentations in the output of Copy Selection as Markdown.
           </p>
         </form>
-
-        <p>
-          Link-text escaping, which spans every generated-link workflow, is on the
-          <a href="advanced.html">Advanced</a> page.
-        </p>
       </div>
       <div class="field is-grouped">
         <div class="control">

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -18,7 +18,6 @@
         <p class="menu-label">General</p>
         <ul class="menu-list">
           <li><a class="is-active" href="options.html">Markdown Style</a></li>
-          <li><a href="options-permissions.html">Permissions</a></li>
           <p class="menu-label">Formats</p>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
@@ -44,6 +43,8 @@
         <p class="menu-label">Others</p>
         <ul class="menu-list">
           <li><a href="menu-commands.html">Menu Commands</a></li>
+          <li><a href="advanced.html">Advanced</a></li>
+          <li><a href="options-permissions.html">Permissions</a></li>
           <li><a href="custom-format-help.html">Help & Examples</a></li>
           <li><a href="about.html">About</a></li>
         </ul>
@@ -117,19 +118,10 @@
           </p>
         </form>
 
-        <form id="form-link-text-always-escape-brackets" class="field">
-          <label class="label">Escaping</label>
-          <div class="control">
-            <label class="checkbox"><input type="checkbox" name="enabled"/> Always escape brackets in link text (<code>[]</code>
-              becomes <code>\[\]</code>)</label>
-          </div>
-          <p class="help">
-            CommonMark allows balanced brackets <code>[]</code> in link text
-            (e.g. <code>[[JIRA-123] My Project](https://link/)</code>).
-            If your Markdown processor does not support this use case, you can enable this feature
-            so that Copy as Markdown always escape brackets in the link text.
-          </p>
-        </form>
+        <p>
+          Link-text escaping, which spans every generated-link workflow, is on the
+          <a href="advanced.html">Advanced</a> page.
+        </p>
       </div>
       <div class="field is-grouped">
         <div class="control">

--- a/src/static/permissions.html
+++ b/src/static/permissions.html
@@ -13,7 +13,7 @@
 <div class="container section content">
     <h1>Copy as Markdown - Permission Required</h1>
     <p>The feature you are going to use requires additional permissions: <code id="permissions-placeholder"></code>. Please grant permissions to use it.</p>
-    <p>You may revoke permission at anytime on the <a href="./options.html" target="_blank">Options</a> page.</p>
+    <p>You may revoke permission at anytime on the <a href="./options-permissions.html" target="_blank">Permissions</a> page.</p>
     <button id="request-permission" class="button is-primary">Grant Permissions</button>
     <button id="close" class="button">Close</button>
 </div>

--- a/src/ui/advanced.ts
+++ b/src/ui/advanced.ts
@@ -1,0 +1,85 @@
+import '../ensure-browser-global.js'; // MUST be first — installs `browser` for old Chrome.
+import Settings from '../lib/settings.js';
+import { hideFlash, showFlash } from './flash.js';
+
+const EscapeBracketsFormId = 'form-link-text-always-escape-brackets';
+
+function escapeBracketsForm(): HTMLFormElement | null {
+  return document.forms.namedItem(EscapeBracketsFormId);
+}
+
+function escapeBracketsCheckbox(): HTMLInputElement | null {
+  const form = escapeBracketsForm();
+  if (!form) return null;
+  return form.elements.namedItem('enabled') as HTMLInputElement | null;
+}
+
+async function loadSettings(): Promise<void> {
+  const { alwaysEscapeLinkBrackets } = await Settings.getAll();
+  const checkbox = escapeBracketsCheckbox();
+  if (checkbox) checkbox.checked = alwaysEscapeLinkBrackets;
+}
+
+/**
+ * Put the checkbox back in sync with what is actually persisted after a write
+ * fails. Re-reading rather than flipping the checkbox back keeps the UI honest
+ * even when the failed write raced a change made on another page.
+ */
+async function refresh(): Promise<void> {
+  try {
+    await loadSettings();
+  } catch (error) {
+    console.error('failed to reload advanced settings after a failed write', error);
+  }
+}
+
+function wireCheckbox(): void {
+  const form = escapeBracketsForm();
+  if (!form) return;
+
+  form.addEventListener('change', async (event) => {
+    const checkbox = event.target;
+    if (!(checkbox instanceof HTMLInputElement)) return;
+
+    try {
+      await Settings.setLinkTextAlwaysEscapeBrackets(checkbox.checked);
+      hideFlash();
+    } catch (error) {
+      console.error('failed to save settings:', error);
+      await refresh();
+      showFlash('Failed to save setting. Please try again.');
+    }
+  });
+}
+
+function wireReset(): void {
+  const resetButton = document.querySelector('#reset');
+  if (!resetButton) return;
+
+  resetButton.addEventListener('click', async () => {
+    try {
+      // Only this page's setting: formatting, menu visibility, and permissions
+      // are owned by their own pages and must survive an Advanced reset.
+      await Settings.reset();
+      await loadSettings();
+      hideFlash();
+    } catch (error) {
+      console.error('failed to reset settings:', error);
+      await refresh();
+      showFlash('Failed to reset settings. Please try again.');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  wireCheckbox();
+  wireReset();
+
+  try {
+    await loadSettings();
+    hideFlash();
+  } catch (error) {
+    console.error('error getting settings', error);
+    showFlash('Failed to load settings. Please try again.');
+  }
+});

--- a/src/ui/options-permissions.ts
+++ b/src/ui/options-permissions.ts
@@ -1,5 +1,4 @@
 import '../ensure-browser-global.js'; // MUST be first — installs `browser` for old Chrome.
-import { resetMarkdownSettings } from '../lib/markdown-settings.js';
 import type { PermissionStatus } from './permissions-ui.js';
 import { hideUiIfPermissionsNotGranted, loadPermissions, PermissionStatusValue } from './permissions-ui.js';
 
@@ -88,8 +87,8 @@ document.querySelectorAll('[data-remove-permission]').forEach((node) => {
 const revokeAllButton = document.querySelector('#revoke-all');
 if (revokeAllButton) {
   revokeAllButton.addEventListener('click', async () => {
-    // Unchanged behavior from when one Settings object owned every preference.
-    await resetMarkdownSettings();
+    // Permissions only. Formatting and menu-visibility settings are owned by
+    // their own pages, and revoking access must not silently reset them.
     const toBeRemoved = Array.from(permissionStatuses.entries())
       .filter(([, stat]) => stat !== PermissionStatusValue.Unavailable)
       .map(([perm]) => perm) as browser._manifest.OptionalPermission[];

--- a/src/ui/options.ts
+++ b/src/ui/options.ts
@@ -2,8 +2,8 @@ import '../ensure-browser-global.js'; // MUST be first — installs `browser` fo
 import type { BulletListMarker, TabGroupIndentationStyle } from '../lib/markdown.js';
 import type { MarkdownSettings } from '../lib/markdown-settings.js';
 import {
+  contextMarkdownSettingsKeys,
   loadMarkdownSettings,
-  markdownSettingsKeys,
   readMarkdownSettings,
   resetMarkdownSettings,
   setSharedBulletListMarker,
@@ -11,7 +11,6 @@ import {
 import MultipleLinksSettings from '../lib/multiple-links-settings.js';
 import type { CodeBlockStyle } from '../lib/selection-settings.js';
 import SelectionSettings from '../lib/selection-settings.js';
-import Settings from '../lib/settings.js';
 import { hideFlash, showFlash } from './flash.js';
 import type { PermissionStatus } from './permissions-ui.js';
 import { disableUiIfPermissionsNotGranted, hideUiIfPermissionsNotGranted, loadPermissions } from './permissions-ui.js';
@@ -35,16 +34,11 @@ function disableTabGroupIndentation(permissionStatuses: PermissionStatus): void 
 
 async function loadSettings(read: () => Promise<MarkdownSettings> = readMarkdownSettings): Promise<void> {
   try {
-    const { alwaysEscapeLinkBrackets, selection, multipleLinks } = await read();
-    const formEscapeBrackets = document.forms.namedItem('form-link-text-always-escape-brackets');
+    const { selection, multipleLinks } = await read();
     const formUnorderedList = document.forms.namedItem('form-style-of-unordered-list');
     const formCodeBlockStyle = document.forms.namedItem('form-style-of-code-block');
     const formTabGroupIndentation = document.forms.namedItem('form-style-of-tab-group-indentation');
 
-    if (formEscapeBrackets) {
-      const checkbox = formEscapeBrackets.elements.namedItem('enabled') as HTMLInputElement | null;
-      if (checkbox) checkbox.checked = alwaysEscapeLinkBrackets;
-    }
     if (formUnorderedList) {
       const character = formUnorderedList.elements.namedItem('character') as RadioNodeList | null;
       if (character) character.value = RadioValueOfMarker[selection.bulletListMarker];
@@ -72,20 +66,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   hideUiIfPermissionsNotGranted(statuses);
   disableTabGroupIndentation(statuses);
 });
-
-const formEscapeBrackets = document.forms.namedItem('form-link-text-always-escape-brackets');
-if (formEscapeBrackets) {
-  formEscapeBrackets.addEventListener('change', async (event) => {
-    try {
-      const target = event.target as HTMLInputElement;
-      await Settings.setLinkTextAlwaysEscapeBrackets(target.checked);
-      hideFlash();
-    } catch (error) {
-      console.error('failed to save settings:', error);
-      showFlash('Failed to save setting. Please try again.');
-    }
-  });
-}
 
 const formTabGroupIndentation = document.forms.namedItem('form-style-of-tab-group-indentation');
 if (formTabGroupIndentation) {
@@ -146,7 +126,7 @@ if (resetButton) {
 }
 
 browser.storage.sync.onChanged.addListener(async (changes) => {
-  const hasSettingsChanged = Object.keys(changes).some(key => markdownSettingsKeys.includes(key));
+  const hasSettingsChanged = Object.keys(changes).some(key => contextMarkdownSettingsKeys.includes(key));
 
   if (hasSettingsChanged) {
     await loadSettings();

--- a/test/e2e/ui/advanced.spec.ts
+++ b/test/e2e/ui/advanced.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * E2E tests for the Advanced options page.
+ *
+ * This page owns link-text escaping, the one Markdown preference that still
+ * spans output contexts. Its reset must restore only that preference, and the
+ * resets owned by other pages must leave it alone.
+ */
+
+import { expect, test } from '../fixtures';
+import type { Page } from '@playwright/test';
+
+function url(extensionId: string, page: string): string {
+  return `chrome-extension://${extensionId}/dist/static/${page}`;
+}
+
+function readSync(page: Page, keys: string[]) {
+  return page.evaluate((keys: string[]) => chrome.storage.sync.get(keys), keys);
+}
+
+test.describe('Advanced page', () => {
+  test('is reachable under Others from other options pages', async ({ page, extensionId }) => {
+    await page.goto(url(extensionId, 'options.html'));
+    await page.waitForLoadState('networkidle');
+
+    const others = page.locator('#menu .menu-label', { hasText: 'Others' }).locator('+ .menu-list');
+    await expect(others.locator('a[href="advanced.html"]')).toHaveText('Advanced');
+    await expect(others.locator('a[href="options-permissions.html"]')).toHaveText('Permissions');
+
+    await page.locator('#menu a[href="advanced.html"]').click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('h2')).toContainText('Advanced');
+  });
+
+  test('keeps Advanced and Permissions under Others on the Advanced page itself', async ({ page, extensionId }) => {
+    await page.goto(url(extensionId, 'advanced.html'));
+    await page.waitForLoadState('networkidle');
+
+    const others = page.locator('#menu .menu-label', { hasText: 'Others' }).locator('+ .menu-list');
+    await expect(others.locator('a[href="advanced.html"]')).toHaveClass(/is-active/);
+    await expect(others.locator('a[href="options-permissions.html"]')).toBeVisible();
+  });
+
+  // Every page carries its own copy of the sidebar, so placement is asserted on
+  // all of them — a page missed during the move is invisible from any one page.
+  const pagesWithNav = [
+    'options.html',
+    'advanced.html',
+    'options-permissions.html',
+    'menu-commands.html',
+    'multiple-links.html',
+    'single-link.html',
+    'custom-format.html',
+    'custom-format-help.html',
+    'about.html',
+  ];
+
+  for (const name of pagesWithNav) {
+    test(`lists Advanced and Permissions under Others on ${name}`, async ({ page, extensionId }) => {
+      await page.goto(url(extensionId, name));
+      await page.waitForLoadState('networkidle');
+
+      const general = page.locator('#menu .menu-label', { hasText: 'General' }).locator('+ .menu-list');
+      const others = page.locator('#menu .menu-label', { hasText: 'Others' }).locator('+ .menu-list');
+
+      await expect(others.locator('a[href="advanced.html"]')).toHaveCount(1);
+      await expect(others.locator('a[href="options-permissions.html"]')).toHaveCount(1);
+      await expect(general.locator('a[href="options-permissions.html"]')).toHaveCount(0);
+    });
+  }
+
+  test('says the preference does not affect Copy Selection', async ({ page, extensionId }) => {
+    await page.goto(url(extensionId, 'advanced.html'));
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('#form-link-text-always-escape-brackets'))
+      .toContainText('does not affect Copy Selection');
+  });
+
+  test('persists the preference across reloads', async ({ page, extensionId }) => {
+    await page.goto(url(extensionId, 'advanced.html'));
+    await page.waitForLoadState('networkidle');
+
+    const checkbox = page.locator('input[name="enabled"]');
+    await expect(checkbox).not.toBeChecked();
+
+    await checkbox.check();
+    await page.waitForTimeout(500);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('input[name="enabled"]')).toBeChecked();
+    expect(await readSync(page, ['linkTextAlwaysEscapeBrackets']))
+      .toEqual({ linkTextAlwaysEscapeBrackets: true });
+  });
+
+  test('reset restores only link-text escaping', async ({ page, extensionId }) => {
+    await page.goto(url(extensionId, 'options.html'));
+    await page.waitForLoadState('networkidle');
+    await page.locator('input[name="character"][value="asterisk"]').check();
+    await page.waitForTimeout(200);
+    await page.locator('input[name="indentation"][value="tab"]').check();
+    await page.waitForTimeout(200);
+
+    await page.goto(url(extensionId, 'advanced.html'));
+    await page.waitForLoadState('networkidle');
+    await page.locator('input[name="enabled"]').check();
+    await page.waitForTimeout(500);
+
+    await page.getByTestId('reset-advanced').click();
+    await page.waitForTimeout(500);
+
+    await expect(page.locator('input[name="enabled"]')).not.toBeChecked();
+
+    // The Markdown Style page's own settings survive untouched.
+    expect(await readSync(page, [
+      'selection.markdown.bulletListMarker',
+      'multipleLinks.markdown.bulletListMarker',
+      'multipleLinks.markdown.tabGroupIndentation',
+    ])).toEqual({
+      'selection.markdown.bulletListMarker': '*',
+      'multipleLinks.markdown.bulletListMarker': '*',
+      'multipleLinks.markdown.tabGroupIndentation': 'tab',
+    });
+  });
+
+  test('survives the Markdown Style page reset', async ({ page, extensionId }) => {
+    await page.goto(url(extensionId, 'advanced.html'));
+    await page.waitForLoadState('networkidle');
+    await page.locator('input[name="enabled"]').check();
+    await page.waitForTimeout(500);
+
+    await page.goto(url(extensionId, 'options.html'));
+    await page.waitForLoadState('networkidle');
+    await page.locator('input[name="character"][value="asterisk"]').check();
+    await page.waitForTimeout(200);
+    await page.locator('#reset').click();
+    await page.waitForTimeout(500);
+
+    await expect(page.locator('input[name="character"][value="dash"]')).toBeChecked();
+
+    await page.goto(url(extensionId, 'advanced.html'));
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('input[name="enabled"]')).toBeChecked();
+  });
+
+  test('survives revoking every permission', async ({ page, extensionId }) => {
+    await page.goto(url(extensionId, 'advanced.html'));
+    await page.waitForLoadState('networkidle');
+    await page.locator('input[name="enabled"]').check();
+    await page.waitForTimeout(500);
+
+    await page.goto(url(extensionId, 'options.html'));
+    await page.waitForLoadState('networkidle');
+    await page.locator('input[name="character"][value="asterisk"]').check();
+    await page.waitForTimeout(200);
+
+    await page.goto(url(extensionId, 'menu-commands.html'));
+    await page.waitForLoadState('networkidle');
+    await page.getByTestId('builtin-tabTitleList').uncheck();
+    await page.waitForTimeout(500);
+
+    await page.goto(url(extensionId, 'options-permissions.html'));
+    await page.waitForLoadState('networkidle');
+    await page.locator('#revoke-all').click();
+    await page.waitForTimeout(500);
+
+    expect(await readSync(page, [
+      'linkTextAlwaysEscapeBrackets',
+      'selection.markdown.bulletListMarker',
+      'builtin.style.tabTitleList',
+    ])).toEqual({
+      'linkTextAlwaysEscapeBrackets': true,
+      'selection.markdown.bulletListMarker': '*',
+      'builtin.style.tabTitleList': false,
+    });
+  });
+});

--- a/test/e2e/ui/options.spec.ts
+++ b/test/e2e/ui/options.spec.ts
@@ -23,10 +23,6 @@ test.describe('Options Page - UI Tests', () => {
       await tabIndentationRadio.check();
       await page.waitForTimeout(200);
 
-      const escapeBracketsCheckbox = page.locator('input[name="enabled"]');
-      await escapeBracketsCheckbox.check();
-      await page.waitForTimeout(500);
-
       // Reload the page
       await page.reload();
       await page.waitForLoadState('networkidle');
@@ -37,9 +33,6 @@ test.describe('Options Page - UI Tests', () => {
 
       const tabIndentationRadioAfter = page.locator('input[name="indentation"][value="tab"]');
       await expect(tabIndentationRadioAfter).toBeChecked();
-
-      const escapeBracketsCheckboxAfter = page.locator('input[name="enabled"]');
-      await expect(escapeBracketsCheckboxAfter).toBeChecked();
     });
 
     test('should reset all settings to default when reset button is clicked', async ({ page, extensionId }) => {
@@ -57,10 +50,6 @@ test.describe('Options Page - UI Tests', () => {
       await tabIndentationRadio.check();
       await page.waitForTimeout(200);
 
-      const escapeBracketsCheckbox = page.locator('input[name="enabled"]');
-      await escapeBracketsCheckbox.check();
-      await page.waitForTimeout(500);
-
       // Click reset button
       const resetButton = page.locator('#reset');
       await resetButton.click();
@@ -72,9 +61,6 @@ test.describe('Options Page - UI Tests', () => {
 
       const spacesIndentationRadio = page.locator('input[name="indentation"][value="spaces"]');
       await expect(spacesIndentationRadio).toBeChecked();
-
-      const escapeBracketsCheckboxAfter = page.locator('input[name="enabled"]');
-      await expect(escapeBracketsCheckboxAfter).not.toBeChecked();
     });
   });
 });

--- a/test/markdown-settings.test.ts
+++ b/test/markdown-settings.test.ts
@@ -109,13 +109,12 @@ describe('markdown settings', () => {
     });
   });
 
-  describe('resetMarkdownSettings() — the combined page reset', () => {
+  describe('resetMarkdownSettings() — the Markdown Style page reset', () => {
     it('restores every setting the page owns', async () => {
       storage.data['selection.markdown.bulletListMarker'] = '+';
       storage.data['selection.markdown.codeBlockStyle'] = 'indented';
       storage.data['multipleLinks.markdown.bulletListMarker'] = '*';
       storage.data['multipleLinks.markdown.tabGroupIndentation'] = 'tab';
-      storage.data.linkTextAlwaysEscapeBrackets = true;
 
       await resetMarkdownSettings();
 
@@ -124,6 +123,14 @@ describe('markdown settings', () => {
         selection: { bulletListMarker: '-', codeBlockStyle: 'fenced' },
         multipleLinks: { bulletListMarker: '-', tabGroupIndentation: 'spaces' },
       });
+    });
+
+    it('leaves link-text escaping to the Advanced page', async () => {
+      storage.data.linkTextAlwaysEscapeBrackets = true;
+
+      await resetMarkdownSettings();
+
+      expect(storage.data.linkTextAlwaysEscapeBrackets).toBe(true);
     });
 
     it('cannot reset some contexts and not others', async () => {

--- a/test/ui/advanced.spec.ts
+++ b/test/ui/advanced.spec.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+
+const settingsMock = {
+  getAll: vi.fn(),
+  setLinkTextAlwaysEscapeBrackets: vi.fn(),
+  reset: vi.fn(),
+  keys: ['linkTextAlwaysEscapeBrackets'],
+};
+
+vi.mock('../../src/lib/settings.js', () => ({
+  __esModule: true,
+  default: settingsMock,
+}));
+
+async function loadPage(): Promise<void> {
+  const response = await fetch('/src/static/advanced.html');
+  const html = await response.text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  document.documentElement.innerHTML = doc.documentElement.innerHTML;
+}
+
+function mockBrowser(): void {
+  (globalThis as any).browser = {
+    storage: { sync: { onChanged: { addListener: vi.fn() } } },
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function startPage(): Promise<void> {
+  await import('../../src/ui/advanced.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await flush();
+}
+
+describe('advanced UI', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockBrowser();
+    settingsMock.getAll.mockResolvedValue({ alwaysEscapeLinkBrackets: false });
+    settingsMock.setLinkTextAlwaysEscapeBrackets.mockResolvedValue(undefined);
+    settingsMock.reset.mockResolvedValue(undefined);
+    await loadPage();
+  });
+
+  it('loads the persisted preference into the checkbox', async () => {
+    settingsMock.getAll.mockResolvedValue({ alwaysEscapeLinkBrackets: true });
+
+    await startPage();
+
+    const checkbox = page.getByRole('checkbox', { name: /Always escape brackets/ });
+    await expect.element(checkbox).toBeChecked();
+  });
+
+  it('saves the preference as soon as the checkbox changes', async () => {
+    await startPage();
+
+    const checkbox = page.getByRole('checkbox', { name: /Always escape brackets/ });
+    await checkbox.click();
+    await flush();
+
+    expect(settingsMock.setLinkTextAlwaysEscapeBrackets).toHaveBeenCalledWith(true);
+    await expect.element(page.getByTestId('flash-error')).not.toBeVisible();
+  });
+
+  it('restores the checkbox to the persisted value and flashes when a save fails', async () => {
+    await startPage();
+    settingsMock.setLinkTextAlwaysEscapeBrackets.mockRejectedValueOnce(new Error('fail'));
+    // Another page enabled it in the meantime: the failed save must show what is
+    // actually persisted, not simply undo the click.
+    settingsMock.getAll.mockResolvedValue({ alwaysEscapeLinkBrackets: true });
+
+    const checkbox = page.getByRole('checkbox', { name: /Always escape brackets/ });
+    await checkbox.click();
+    await flush();
+
+    await expect.element(checkbox).toBeChecked();
+    await expect.element(page.getByTestId('flash-error')).toBeVisible();
+  });
+
+  it('resets only the link-text escaping preference', async () => {
+    settingsMock.getAll.mockResolvedValue({ alwaysEscapeLinkBrackets: true });
+    await startPage();
+
+    settingsMock.getAll.mockResolvedValue({ alwaysEscapeLinkBrackets: false });
+    await page.getByTestId('reset-advanced').click();
+    await flush();
+
+    expect(settingsMock.reset).toHaveBeenCalledTimes(1);
+    await expect.element(page.getByRole('checkbox', { name: /Always escape brackets/ })).not.toBeChecked();
+  });
+
+  it('flashes and re-reads the persisted value when a reset fails', async () => {
+    settingsMock.getAll.mockResolvedValue({ alwaysEscapeLinkBrackets: true });
+    await startPage();
+
+    settingsMock.reset.mockRejectedValueOnce(new Error('fail'));
+    await page.getByTestId('reset-advanced').click();
+    await flush();
+
+    await expect.element(page.getByRole('checkbox', { name: /Always escape brackets/ })).toBeChecked();
+    await expect.element(page.getByTestId('flash-error')).toBeVisible();
+  });
+
+  it('shows an error when the initial load fails', async () => {
+    settingsMock.getAll.mockRejectedValueOnce(new Error('fail'));
+
+    await startPage();
+
+    await expect.element(page.getByTestId('flash-error')).toBeVisible();
+  });
+
+  it('says the preference does not affect Copy Selection', async () => {
+    await startPage();
+
+    expect(document.body.textContent).toContain('does not affect Copy Selection');
+  });
+});

--- a/test/ui/options-permissions.spec.ts
+++ b/test/ui/options-permissions.spec.ts
@@ -1,13 +1,7 @@
 import { page } from 'vitest/browser';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
-const resetMarkdownSettingsMock = vi.fn();
-
 const loadPermissionsMock = vi.fn();
-
-vi.mock('../../src/lib/markdown-settings.js', () => ({
-  resetMarkdownSettings: resetMarkdownSettingsMock,
-}));
 
 vi.mock('../../src/ui/permissions-ui.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/ui/permissions-ui.js')>();
@@ -115,11 +109,10 @@ describe('options permissions UI', () => {
     await expect.element(bookmarksBadge).toHaveTextContent('Unsupported');
   });
 
-  it('revokes all permissions via reset button', async () => {
+  it('revokes all permissions via reset button, leaving settings alone', async () => {
     // Use the existing mocks from the global browser object set up in beforeAll
     const removeMock = (globalThis as any).browser.permissions.remove;
 
-    resetMarkdownSettingsMock.mockClear();
     removeMock.mockClear();
 
     const revokeAll = page.getByRole('button', { name: /Revoke All/ });
@@ -128,7 +121,6 @@ describe('options permissions UI', () => {
     await revokeAll.click();
     await flush();
 
-    expect(resetMarkdownSettingsMock).toHaveBeenCalledTimes(1);
     // Only tabs is granted in the initial setup, bookmarks is unavailable
     // So only tabs and tabGroups are in the revoke call
     expect(removeMock).toHaveBeenCalledWith({ permissions: ['tabs', 'tabGroups'] });

--- a/test/ui/options.spec.ts
+++ b/test/ui/options.spec.ts
@@ -1,12 +1,6 @@
 import { page } from 'vitest/browser';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
-const settingsMock = {
-  setLinkTextAlwaysEscapeBrackets: vi.fn(),
-  reset: vi.fn(),
-  keys: [],
-};
-
 const selectionSettingsMock = {
   setBulletListMarker: vi.fn(),
   setCodeBlockStyle: vi.fn(),
@@ -33,11 +27,6 @@ const PermissionStatusValue = {
   Unavailable: 'unavailable',
 } as const;
 
-// Mock the settings modules
-vi.mock('../../src/lib/settings.js', () => ({
-  default: settingsMock,
-}));
-
 vi.mock('../../src/lib/selection-settings.js', () => ({
   default: selectionSettingsMock,
 }));
@@ -47,7 +36,7 @@ vi.mock('../../src/lib/multiple-links-settings.js', () => ({
 }));
 
 vi.mock('../../src/lib/markdown-settings.js', () => ({
-  markdownSettingsKeys: [],
+  contextMarkdownSettingsKeys: [],
   readMarkdownSettings: readMarkdownSettingsMock,
   loadMarkdownSettings: loadMarkdownSettingsMock,
   setSharedBulletListMarker: setSharedBulletListMarkerMock,
@@ -107,9 +96,6 @@ describe('options UI - with permissions granted', () => {
   });
 
   it('loads settings into the form', async () => {
-    const escapeCheckbox = page.getByRole('checkbox', { name: /Always escape brackets/ });
-    await expect.element(escapeCheckbox).toBeChecked();
-
     const asteriskRadio = page.getByRole('radio', { name: /Asterisks/ });
     await expect.element(asteriskRadio).toBeChecked();
 
@@ -134,21 +120,8 @@ describe('options UI - with permissions granted', () => {
     await expect.element(page.getByTestId('requires-permissions-tab-groups')).to.toHaveClass('is-hidden');
   });
 
-  it('saves settings on change', async () => {
-    settingsMock.setLinkTextAlwaysEscapeBrackets.mockClear();
-    settingsMock.setLinkTextAlwaysEscapeBrackets.mockResolvedValue(undefined);
-
-    const escapeCheckbox = page.getByRole('checkbox', { name: /Always escape brackets/ });
-    await expect.element(escapeCheckbox).toBeInTheDocument();
-
-    // Toggle the checkbox
-    await escapeCheckbox.click();
-
-    expect(settingsMock.setLinkTextAlwaysEscapeBrackets).toHaveBeenCalledWith(false);
-
-    // Verify no error flash is shown
-    const flash = page.getByTestId('flash-error');
-    await expect.element(flash).not.toBeVisible();
+  it('no longer presents the link-text escaping control', async () => {
+    expect(document.querySelector('#form-link-text-always-escape-brackets')).toBeNull();
   });
 
   it('writes the bullet list marker for both contexts in one save', async () => {


### PR DESCRIPTION

## Summary

Closes #294

<img width="949" height="914" alt="截圖 2026-08-12 凌晨12 32 06" src="https://github.com/user-attachments/assets/d7ac4cc8-a5a5-4e2b-99c0-d3bebc0e74d3" />

## Tests

<!-- If you have only 1 OS available, you can just test on that one -->

- [ ] Chrome stable (macOS)
- [ ] Firefox stable (macOS)
- [ ] Chrome stable (Windows)
- [ ] Firefox stable (Windows)

Optional:

- [ ] Chrome beta (macOS)
- [ ] Firefox beta (macOS)
- [ ] Chrome beta (Windows)
- [ ] Firefox beta (Windows)


## AI Disclosure

<!-- Check one. Be honest. 

It is okay to use coding agents to discover, build features and fix bugs, 
but you are ultimately responsible for the patch.

This project does not welcome YOLO coding. -->

- [x] I used coding agents to create this patch. I understand and am responsible for all the code it generates.
- [ ] I did not use any coding agent to create this patch. I am responsible for all the code I wrote.
