### PR TITLE
Give Copy Selection and Multiple Links independent formatting pages

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -187,9 +187,19 @@ npm run test:e2e:selenium
 
 This builds the `firefox-test` extension bundle and then runs `pytest e2e_test/ -v` under `xvfb-run`. `xvfb-run` is required — pyautogui sends X11 key events for keyboard-shortcut tests and needs a real (or virtual) display.
 
-**CI:** The `selenium` GitHub Actions job runs this suite natively on `ubuntu-latest` after the `build` job succeeds.
+**Docker (canonical / CI parity):**
 
-**Docker (coming soon):** A Docker variant (`test:e2e:selenium:docker`) for local Mac parity will be added in a follow-up branch, following the same pattern as `docker/playwright-ci/`.
+```sh
+npm run test:e2e:selenium:docker
+```
+
+This runs [docker/selenium-ci/docker-e2e.sh](docker/selenium-ci/docker-e2e.sh), following the same
+pattern as `docker/playwright-ci/`: it builds the image, runs the suite under Xvfb with `CI=true`,
+mounts `test-results/` back to the host, and prunes only the dangling image this project's previous
+build orphaned.
+
+**CI:** The `selenium` GitHub Actions job runs `docker/selenium-ci/docker-e2e.sh` — the same
+entrypoint — after the `build` job succeeds.
 
 ## Debugging the extension
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -34,7 +34,7 @@ The extension is built with **esbuild**, once per target (`chrome` and `firefox-
    import them — there is no `src/vendor` snapshot and no `postinstall` copy step.
 
 The entry points are listed in `entryPointsFor()` in `scripts/lib/build-extension.js`: `background`
-+ the seven UI page scripts for both targets, plus `offscreen` for Chrome only (Firefox has no
++ the eight UI page scripts for both targets, plus `offscreen` for Chrome only (Firefox has no
 offscreen API).
 
 ## Compile-time target flag (`BUILD_TARGET`)

--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -63,6 +63,9 @@ class FirefoxBrowserEnvironment:
     def options_page_url(self):
         return f"{self._extension_base_url}/dist/static/options.html"
 
+    def multiple_links_page_url(self):
+        return f"{self._extension_base_url}/dist/static/multiple-links.html"
+
     def custom_format_page_url(self, context: str, slot: int):
         return f"{self._extension_base_url}/dist/static/custom-format.html?context={context}&slot={slot}"
 
@@ -132,12 +135,20 @@ class FirefoxBrowserEnvironment:
             self.driver.close()
             self.driver.switch_to.window(original_window)
 
-    def macro_change_format_style(self, ul_style: str, indent_style: str | None = None):
+    def macro_change_multiple_links_format_style(self, bullet_list_marker: str, indent_style: str | None = None):
+        """Set the built-in tab-export formatting on the Multiple Links options page.
+
+        Both settings are owned by that page; the marker is stored as the literal
+        Markdown token, so pass `-`, `*`, or `+`. Copy Selection has its own
+        marker on its own page and is unaffected.
+        """
         original_window = self.driver.current_window_handle
         self.driver.switch_to.new_window('tab')
-        self.driver.get(self.options_page_url())
+        self.driver.get(self.multiple_links_page_url())
 
-        self.driver.find_element(By.CSS_SELECTOR, f"[name=character][value='{ul_style}']").click()
+        self.driver.find_element(
+            By.CSS_SELECTOR, f"[name=bullet-list-marker][value='{bullet_list_marker}']"
+        ).click()
 
         if indent_style is not None:
             indent_option = self.driver.find_element(By.CSS_SELECTOR, f"[name=indentation][value='{indent_style}']")

--- a/e2e_test/test_tabs_exporting.py
+++ b/e2e_test/test_tabs_exporting.py
@@ -50,7 +50,7 @@ class TestTabsExporting:
     @pytest.fixture(scope="class")
     @classmethod
     def set_default_format_style(cls):
-        cls.browser.macro_change_format_style("dash", "spaces")
+        cls.browser.macro_change_multiple_links_format_style("-", "spaces")
         yield
 
     def test_all_tabs_keyboard_shortcut(self, set_default_format_style):

--- a/scripts/lib/build-extension.js
+++ b/scripts/lib/build-extension.js
@@ -13,6 +13,7 @@ const sharedEntries = [
   'src/ui/options-permissions.ts',
   'src/ui/permissions.ts',
   'src/ui/custom-format.ts',
+  'src/ui/multiple-links.ts',
   'src/ui/menu-commands.ts',
   'src/ui/advanced.ts',
 ];

--- a/src/lib/legacy-markdown-settings.ts
+++ b/src/lib/legacy-markdown-settings.ts
@@ -1,0 +1,15 @@
+/**
+ * Storage keys written by versions that predate context-owned settings.
+ *
+ * [sic.] Two of them have a trailing space, introduced by a typo when they were
+ * added. They are matched verbatim here; migration is what finally retires them.
+ *
+ * This module deliberately depends on nothing: both the migration and the
+ * context settings modules name these keys, and the migration already imports
+ * the context modules.
+ */
+export const LegacyMarkdownSettingKeys = {
+  unorderedList: 'styleOfUnorderedList ',
+  codeBlock: 'styleOfCodeBlock',
+  tabGroupIndentation: 'style.tabgroup.indentation ',
+} as const;

--- a/src/lib/markdown-settings-migration.ts
+++ b/src/lib/markdown-settings-migration.ts
@@ -1,20 +1,11 @@
+import { LegacyMarkdownSettingKeys } from './legacy-markdown-settings.js';
 import type { BulletListMarker } from './markdown.js';
 import { isBulletListMarker, isTabGroupIndentationStyle } from './markdown.js';
 import MultipleLinksSettings, { MultipleLinksSettingDefaults, MultipleLinksSettingKeys } from './multiple-links-settings.js';
 import type { CodeBlockStyle } from './selection-settings.js';
 import SelectionSettings, { isCodeBlockStyle, SelectionSettingDefaults, SelectionSettingKeys } from './selection-settings.js';
 
-/**
- * Storage keys written by versions that predate context-owned settings.
- *
- * [sic.] Two of them have a trailing space, introduced by a typo when they were
- * added. They are matched verbatim here; migration is what finally retires them.
- */
-export const LegacyMarkdownSettingKeys = {
-  unorderedList: 'styleOfUnorderedList ',
-  codeBlock: 'styleOfCodeBlock',
-  tabGroupIndentation: 'style.tabgroup.indentation ',
-} as const;
+export { LegacyMarkdownSettingKeys };
 
 const LegacyUnorderedListMarkers: Record<string, BulletListMarker> = {
   dash: '-',

--- a/src/lib/markdown-settings.ts
+++ b/src/lib/markdown-settings.ts
@@ -1,9 +1,10 @@
-import type { BulletListMarker } from './markdown.js';
-import { LegacyMarkdownSettingKeys, migrateMarkdownSettings } from './markdown-settings-migration.js';
+import { LegacyMarkdownSettingKeys } from './legacy-markdown-settings.js';
+import { isBulletListMarker } from './markdown.js';
+import { migrateMarkdownSettings } from './markdown-settings-migration.js';
 import type { MultipleLinksMarkdownSettings } from './multiple-links-settings.js';
-import MultipleLinksSettings, { MultipleLinksSettingKeys } from './multiple-links-settings.js';
+import MultipleLinksSettings, { MultipleLinksSettingDefaults, MultipleLinksSettingKeys } from './multiple-links-settings.js';
 import type { SelectionMarkdownSettings } from './selection-settings.js';
-import SelectionSettings, { SelectionSettingKeys } from './selection-settings.js';
+import SelectionSettings, { SelectionSettingDefaults, SelectionSettingKeys } from './selection-settings.js';
 import Settings from './settings.js';
 
 export interface MarkdownSettings {
@@ -12,16 +13,16 @@ export interface MarkdownSettings {
   multipleLinks: MultipleLinksMarkdownSettings;
 }
 
-/** The keys owned by an output context — everything the Markdown Style page presents. */
-export const contextMarkdownSettingsKeys: string[] = [
-  ...SelectionSettings.keys,
-  ...MultipleLinksSettings.keys,
-];
-
-/** Every storage key whose change should re-read the settings above. */
+/**
+ * Every storage key whose change should re-read the settings above.
+ *
+ * Each options page watches only the keys its own context owns; this is the
+ * union the background script watches, since it applies all of them.
+ */
 export const markdownSettingsKeys: string[] = [
   ...Settings.keys,
-  ...contextMarkdownSettingsKeys,
+  ...SelectionSettings.keys,
+  ...MultipleLinksSettings.keys,
 ];
 
 /**
@@ -43,40 +44,109 @@ export async function readMarkdownSettings(): Promise<MarkdownSettings> {
 }
 
 /**
- * Point both contexts at one bullet-list marker, in a single write.
+ * Bring a legacy profile into context-owned storage, logging any failure.
  *
- * Transitional: the combined settings page still presents one Unordered List
- * Character control for Copy Selection and Multiple Links. Two sequential
- * writes could half-succeed and leave the contexts permanently disagreeing
- * behind a single radio group, so they move together — exactly as atomically
- * as they did when one storage key backed the control.
+ * Every options page that shows a migrated preference calls this before its
+ * first read, so whichever page the user opens first shows their real choice
+ * rather than a default. Migration is idempotent, so racing the background
+ * copy — or another options page — is safe. Failures are swallowed: the legacy
+ * keys survive for the next attempt and reads fall back to defaults meanwhile.
  */
-export async function setSharedBulletListMarker(marker: BulletListMarker): Promise<void> {
-  await browser.storage.sync.set({
-    [SelectionSettingKeys.bulletListMarker]: marker,
-    [MultipleLinksSettingKeys.bulletListMarker]: marker,
-  });
+export async function ensureMarkdownSettingsMigrated(): Promise<void> {
+  try {
+    const result = await migrateMarkdownSettings();
+    if (result.status === 'write-failed' || result.status === 'removal-failed') {
+      console.error('failed to migrate Markdown settings', result.status, result.error);
+    }
+  } catch (error) {
+    console.error('failed to migrate Markdown settings', error);
+  }
+}
+
+interface ContextResetPlan {
+  /** Every key the context owns. */
+  keys: string[];
+  /** Those same keys mapped to their defaults. */
+  defaults: Record<string, unknown>;
+  /** Legacy keys only this context migrates from. */
+  exclusiveLegacyKeys: string[];
+  /** The other context's bullet-marker key — the other half of the shared legacy source. */
+  siblingBulletListMarkerKey: string;
+}
+
+function isPresent(stored: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(stored, key);
 }
 
 /**
- * Restore every Markdown setting the Markdown Style page owns, in a single removal.
+ * Restore one context to its defaults, and retire the legacy keys it migrates
+ * from — but never at the other context's expense.
  *
- * Transitional for the same reason as `setSharedBulletListMarker`: one visible
- * "Restore to Default" button must not be able to reset some contexts and not
- * others. Per-page resets replace this.
+ * Legacy retirement lives here rather than in the context modules because the
+ * unordered-list key is the migration source for *both* contexts. A context
+ * cannot see whether its sibling has materialized a copy yet, so it must not be
+ * the one to decide that key is spent.
  *
- * Link-text escaping is deliberately absent: the Advanced page owns it and
- * resets it on its own, so neither reset can silently undo the other.
- *
- * Legacy keys go too. A migration whose cleanup failed leaves them behind, and
- * a reset that spared them would be undone by the next startup re-migrating
- * the old values over the defaults the user just asked for.
+ * The reset first runs the (idempotent) migration, which normally materializes
+ * both contexts and clears the legacy keys itself, leaving nothing to decide.
+ * When the shared legacy marker outlives that — a failed migration write, or a
+ * sibling value this version cannot read — it is still the sibling's only copy,
+ * so it stays, and this context persists its defaults instead of removing its
+ * keys. A present value always beats a legacy one during migration, so the
+ * reset is just as final while the sibling keeps its chance to migrate.
  */
-export async function resetMarkdownSettings(): Promise<void> {
-  await browser.storage.sync.remove([
-    ...contextMarkdownSettingsKeys,
-    ...Object.values(LegacyMarkdownSettingKeys),
+async function resetContext(plan: ContextResetPlan): Promise<void> {
+  await ensureMarkdownSettingsMigrated();
+
+  const stored = await browser.storage.sync.get([
+    LegacyMarkdownSettingKeys.unorderedList,
+    plan.siblingBulletListMarkerKey,
   ]);
+
+  const sharedLegacyMarkerRemains = isPresent(stored, LegacyMarkdownSettingKeys.unorderedList);
+  // Present but unreadable counts as not materialized: migration keeps the
+  // legacy key alive for exactly that case, and so must this.
+  const siblingIsMaterialized = isBulletListMarker(stored[plan.siblingBulletListMarkerKey]);
+
+  if (sharedLegacyMarkerRemains && !siblingIsMaterialized) {
+    await browser.storage.sync.set(plan.defaults);
+    if (plan.exclusiveLegacyKeys.length > 0) {
+      await browser.storage.sync.remove(plan.exclusiveLegacyKeys);
+    }
+    return;
+  }
+
+  await browser.storage.sync.remove([
+    ...plan.keys,
+    ...plan.exclusiveLegacyKeys,
+    ...(sharedLegacyMarkerRemains ? [LegacyMarkdownSettingKeys.unorderedList] : []),
+  ]);
+}
+
+/** The Copy Selection page's reset. Leaves every other context untouched. */
+export async function resetSelectionSettings(): Promise<void> {
+  await resetContext({
+    keys: SelectionSettings.keys,
+    defaults: {
+      [SelectionSettingKeys.bulletListMarker]: SelectionSettingDefaults.bulletListMarker,
+      [SelectionSettingKeys.codeBlockStyle]: SelectionSettingDefaults.codeBlockStyle,
+    },
+    exclusiveLegacyKeys: [LegacyMarkdownSettingKeys.codeBlock],
+    siblingBulletListMarkerKey: MultipleLinksSettingKeys.bulletListMarker,
+  });
+}
+
+/** The Multiple Links page's reset. Leaves every other context untouched. */
+export async function resetMultipleLinksSettings(): Promise<void> {
+  await resetContext({
+    keys: MultipleLinksSettings.keys,
+    defaults: {
+      [MultipleLinksSettingKeys.bulletListMarker]: MultipleLinksSettingDefaults.bulletListMarker,
+      [MultipleLinksSettingKeys.tabGroupIndentation]: MultipleLinksSettingDefaults.tabGroupIndentation,
+    },
+    exclusiveLegacyKeys: [LegacyMarkdownSettingKeys.tabGroupIndentation],
+    siblingBulletListMarkerKey: SelectionSettingKeys.bulletListMarker,
+  });
 }
 
 /**
@@ -88,14 +158,6 @@ export async function resetMarkdownSettings(): Promise<void> {
  * survive for the next attempt, and reads fall back to the defaults meanwhile.
  */
 export async function loadMarkdownSettings(): Promise<MarkdownSettings> {
-  try {
-    const result = await migrateMarkdownSettings();
-    if (result.status === 'write-failed' || result.status === 'removal-failed') {
-      console.error('failed to migrate Markdown settings', result.status, result.error);
-    }
-  } catch (error) {
-    console.error('failed to migrate Markdown settings', error);
-  }
-
+  await ensureMarkdownSettingsMigrated();
   return await readMarkdownSettings();
 }

--- a/src/lib/multiple-links-settings.ts
+++ b/src/lib/multiple-links-settings.ts
@@ -22,6 +22,9 @@ export const MultipleLinksSettingDefaults: MultipleLinksMarkdownSettings = {
  * Only the built-in list marker lives here; task lists keep their fixed
  * `- [ ]` marker. Persisted values are validated per setting and an invalid
  * stored value is never rewritten during a read.
+ *
+ * Resetting this context lives in `markdown-settings.ts`, for the reason given
+ * on the Copy Selection settings module.
  */
 export default {
   keys: Object.values(MultipleLinksSettingKeys) as string[],
@@ -48,9 +51,5 @@ export default {
 
   async setTabGroupIndentation(value: TabGroupIndentationStyle): Promise<void> {
     await browser.storage.sync.set({ [MultipleLinksSettingKeys.tabGroupIndentation]: value });
-  },
-
-  async reset(): Promise<void> {
-    await browser.storage.sync.remove(this.keys);
   },
 };

--- a/src/lib/selection-settings.ts
+++ b/src/lib/selection-settings.ts
@@ -31,6 +31,10 @@ export const SelectionSettingDefaults: SelectionMarkdownSettings = {
  * context's allowlist and falls back on its own default when invalid. An
  * invalid stored value is never rewritten during a read — it may belong to a
  * newer version of the extension.
+ *
+ * Resetting this context lives in `markdown-settings.ts`: retiring the legacy
+ * keys it migrates from needs a view of both contexts, which this module does
+ * not have.
  */
 export default {
   keys: Object.values(SelectionSettingKeys) as string[],
@@ -57,9 +61,5 @@ export default {
 
   async setCodeBlockStyle(value: CodeBlockStyle): Promise<void> {
     await browser.storage.sync.set({ [SelectionSettingKeys.codeBlockStyle]: value });
-  },
-
-  async reset(): Promise<void> {
-    await browser.storage.sync.remove(this.keys);
   },
 };

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -30,6 +30,12 @@ export default {
     });
   },
 
+  /**
+   * Restore the default by removing the key.
+   *
+   * Unlike the context-owned resets, this preference has no legacy key of its
+   * own to clear alongside it — it was never renamed.
+   */
   async reset(): Promise<void> {
     await browser.storage.sync.remove(this.keys);
   },

--- a/src/static/about.html
+++ b/src/static/about.html
@@ -15,10 +15,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a href="options.html">Copy Selection</a></li>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list" data-menu-custom-format-context="multiple-links">

--- a/src/static/advanced.html
+++ b/src/static/advanced.html
@@ -15,10 +15,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a href="options.html">Copy Selection</a></li>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list" data-menu-custom-format-context="multiple-links">

--- a/src/static/custom-format-help.html
+++ b/src/static/custom-format-help.html
@@ -15,10 +15,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a href="options.html">Copy Selection</a></li>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list" data-menu-custom-format-context="multiple-links">

--- a/src/static/custom-format.html
+++ b/src/static/custom-format.html
@@ -13,10 +13,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a href="options.html">Copy Selection</a></li>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list">

--- a/src/static/menu-commands.html
+++ b/src/static/menu-commands.html
@@ -15,10 +15,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a href="options.html">Copy Selection</a></li>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list" data-menu-custom-format-context="multiple-links">

--- a/src/static/multiple-links.html
+++ b/src/static/multiple-links.html
@@ -15,10 +15,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a href="options.html">Copy Selection</a></li>
           <li>
             <a class="is-active" href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list" data-menu-custom-format-context="multiple-links">
@@ -54,12 +53,69 @@
       <div class="box content">
         <h2 class="title is-3">Formats - Multiple Links</h2>
         <p>
-          Which tab export commands appear in menus is on the
+          These settings apply to the built-in tab export commands only.
+          Which of those commands appear in menus is on the
           <a href="menu-commands.html">Menu Commands</a> page.
         </p>
+
+        <form id='form-multiple-links-bullet-list-marker' class="field">
+          <label class="label">Unordered List Character</label>
+          <div class="control">
+            <label class="radio">
+              <input type="radio" name="bullet-list-marker" value="-"/>
+              Dashes (<code>-</code>)
+            </label>
+          </div>
+          <div class="control">
+            <label class="radio">
+              <input type="radio" name="bullet-list-marker" value="*"/>
+              Asterisks (<code>*</code>)
+            </label>
+          </div>
+          <div class="control">
+            <label class="radio">
+              <input type="radio" name="bullet-list-marker" value="+"/>
+              Plus Signs (<code>+</code>)
+            </label>
+          </div>
+          <p class="help">
+            The character that starts each item of a built-in list export.
+            Task lists keep their fixed <code>- [ ]</code> marker.
+          </p>
+        </form>
+
+        <form id='form-multiple-links-tab-group-indentation' class="field">
+          <label class="label">Tab Group Indentation <span class="tag" data-hide-if-permission-contains="tabGroups" data-testid="requires-permissions-tab-groups">Requires Permission</span></label>
+          <div class="control">
+            <label class="radio">
+              <input type="radio" name="indentation" value="spaces" data-dependson-permissions="tabGroups"/>
+              Spaces
+            </label>
+          </div>
+          <div class="control">
+            <label class="radio">
+              <input type="radio" name="indentation" value="tab" data-dependson-permissions="tabGroups"/>
+              Tab
+            </label>
+          </div>
+          <p class="help">
+            CommonMark uses spaces to indent nested lists, which are used when exporting tabs along with tab groups.
+            The number of spaces required depends on the leading characters of the parent item.
+            If your Markdown processor prefers <kbd>tab</kbd> (<code>\t</code>) characters for indentation,
+            choose <strong>Tab</strong> so that Copy as Markdown outputs tabs for indentation.
+            Please note that this option does not affect indentations in the output of Copy Selection as Markdown.
+          </p>
+        </form>
       </div>
+      <div class="field is-grouped">
+        <div class="control">
+          <button id="reset" data-testid="reset-multiple-links" type="button" class="button is-outlined is-danger">Restore Multiple Links Defaults</button>
+        </div>
+      </div>
+      <p class="help">Restores this page's settings only. Copy Selection, menu, and other settings are left untouched.</p>
     </div>
   </div>
 </div>
+<script src="../ui/multiple-links.js" type="module"></script>
 </body>
 </html>

--- a/src/static/options-permissions.html
+++ b/src/static/options-permissions.html
@@ -15,10 +15,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a href="options.html">Copy Selection</a></li>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list" data-menu-custom-format-context="multiple-links">

--- a/src/static/options.html
+++ b/src/static/options.html
@@ -15,10 +15,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a class="is-active" href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a class="is-active" href="options.html">Copy Selection</a></li>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list" data-menu-custom-format-context="multiple-links">
@@ -52,30 +51,38 @@
     </div>
     <div class="column">
       <div class="box content">
-        <h2 class="title is-3">Markdown Style</h2>
-        <form id='form-style-of-unordered-list' class="field">
+        <h2 class="title is-3">Formats - Copy Selection</h2>
+        <p>
+          These settings apply to <strong>Copy Selection as Markdown</strong> only.
+          Tab exports are configured on the <a href="multiple-links.html">Multiple Links</a> page.
+        </p>
+
+        <form id='form-selection-bullet-list-marker' class="field">
           <label class="label">Unordered List Character</label>
           <div class="control">
             <label class="radio">
-              <input type="radio" name="character" value="dash"/>
+              <input type="radio" name="bullet-list-marker" value="-"/>
               Dashes (<code>-</code>)
             </label>
           </div>
           <div class="control">
             <label class="radio">
-              <input type="radio" name="character" value="asterisk"/>
+              <input type="radio" name="bullet-list-marker" value="*"/>
               Asterisks (<code>*</code>)
             </label>
           </div>
           <div class="control">
             <label class="radio">
-              <input type="radio" name="character" value="plus"/>
+              <input type="radio" name="bullet-list-marker" value="+"/>
               Plus Signs (<code>+</code>)
             </label>
           </div>
+          <p class="help">
+            The character that starts each item when a selected HTML list is converted to Markdown.
+          </p>
         </form>
 
-        <form id='form-style-of-code-block' class="field">
+        <form id='form-selection-code-block-style' class="field">
           <label class="label">Code Block Style</label>
           <div class="control">
             <label class="radio">
@@ -94,35 +101,13 @@
             Fenced style keeps language tags for syntax highlighting, while indented style omits language tags.
           </p>
         </form>
-
-        <form id='form-style-of-tab-group-indentation' class="field">
-          <label class="label">Tab Group Indentation <span class="tag" data-hide-if-permission-contains="tabGroups" data-testid="requires-permissions-tab-groups">Requires Permission</span></label>
-          <div class="control">
-            <label class="radio">
-              <input type="radio" name="indentation" value="spaces" data-dependson-permissions="tabGroups"/>
-              Spaces
-            </label>
-          </div>
-          <div class="control">
-            <label class="radio">
-              <input type="radio" name="indentation" value="tab" data-dependson-permissions="tabGroups"/>
-              Tab
-            </label>
-          </div>
-          <p class="help">
-            CommonMark uses spaces to indent nested lists, which are used when exporting tabs along with tab groups.
-            The number of spaces required depends on the leading characters of the parent item.
-            If your Markdown processor prefers <kbd>tab</kbd> (<code>\t</code>) characters for indentation,
-            choose <strong>Tab</strong> so that Copy as Markdown outputs tabs for indentation.
-            Please note that this option does not affect indentations in the output of Copy Selection as Markdown.
-          </p>
-        </form>
       </div>
       <div class="field is-grouped">
         <div class="control">
-          <button id="reset" type="button" class="button is-outlined is-danger">Restore to Default</button>
+          <button id="reset" data-testid="reset-copy-selection" type="button" class="button is-outlined is-danger">Restore Copy Selection Defaults</button>
         </div>
       </div>
+      <p class="help">Restores this page's settings only. Multiple Links, menu, and other settings are left untouched.</p>
     </div>
   </div>
     <script src="../ui/options.js" type="module"></script>

--- a/src/static/single-link.html
+++ b/src/static/single-link.html
@@ -15,10 +15,9 @@
   <div class="columns">
     <div class="column is-narrow" id="menu">
       <aside class="menu">
-        <p class="menu-label">General</p>
+        <p class="menu-label">Formats</p>
         <ul class="menu-list">
-          <li><a href="options.html">Markdown Style</a></li>
-          <p class="menu-label">Formats</p>
+          <li><a href="options.html">Copy Selection</a></li>
           <li>
             <a href="multiple-links.html">Multiple Links</a>
             <ul class="menu-list" data-menu-custom-format-context="multiple-links">
@@ -52,7 +51,7 @@
     </div>
     <div class="column">
       <div class="box content">
-        <h2 class="title is-3">Format - Single Link</h2>
+        <h2 class="title is-3">Formats - Single Link</h2>
         <p>
           Single Link has no settings of its own yet. Its custom formats are in the menu on the left,
           and which commands appear in menus is on the

--- a/src/ui/multiple-links.ts
+++ b/src/ui/multiple-links.ts
@@ -1,15 +1,16 @@
 import '../ensure-browser-global.js'; // MUST be first — installs `browser` for old Chrome.
-import { isBulletListMarker } from '../lib/markdown.js';
-import { ensureMarkdownSettingsMigrated, resetSelectionSettings } from '../lib/markdown-settings.js';
-import SelectionSettings, { isCodeBlockStyle } from '../lib/selection-settings.js';
+import { isBulletListMarker, isTabGroupIndentationStyle } from '../lib/markdown.js';
+import { ensureMarkdownSettingsMigrated, resetMultipleLinksSettings } from '../lib/markdown-settings.js';
+import MultipleLinksSettings from '../lib/multiple-links-settings.js';
 import { hideFlash, showFlash } from './flash.js';
+import { disableUiIfPermissionsNotGranted, hideUiIfPermissionsNotGranted, loadPermissions } from './permissions-ui.js';
 
-// The Copy Selection page. It is also the extension's options landing page, so
-// it owns nothing but its own context: the bullet-list marker used when a
-// selected HTML list is converted, and the code-block style.
+// The Multiple Links page. It owns the marker used by the built-in list
+// exports — task lists keep their fixed `- [ ]` marker — and the indentation
+// used when tabs are exported along with their tab groups.
 
-const BulletListMarkerFormId = 'form-selection-bullet-list-marker';
-const CodeBlockStyleFormId = 'form-selection-code-block-style';
+const BulletListMarkerFormId = 'form-multiple-links-bullet-list-marker';
+const TabGroupIndentationFormId = 'form-multiple-links-tab-group-indentation';
 
 function radioGroup(formId: string, name: string): RadioNodeList | null {
   const form = document.forms.namedItem(formId);
@@ -18,25 +19,25 @@ function radioGroup(formId: string, name: string): RadioNodeList | null {
 }
 
 async function loadSettings(): Promise<void> {
-  const { bulletListMarker, codeBlockStyle } = await SelectionSettings.getAll();
+  const { bulletListMarker, tabGroupIndentation } = await MultipleLinksSettings.getAll();
 
   const markers = radioGroup(BulletListMarkerFormId, 'bullet-list-marker');
   if (markers) markers.value = bulletListMarker;
 
-  const codeBlockStyles = radioGroup(CodeBlockStyleFormId, 'code-block-style');
-  if (codeBlockStyles) codeBlockStyles.value = codeBlockStyle;
+  const indentations = radioGroup(TabGroupIndentationFormId, 'indentation');
+  if (indentations) indentations.value = tabGroupIndentation;
 }
 
 /**
  * Put the controls back in sync with what is actually persisted after a write
- * fails. Re-reading rather than restoring the previous selection keeps the UI
- * honest even when the failed write raced a change made elsewhere.
+ * fails, rather than merely undoing the click — another page may have changed
+ * the same setting in the meantime.
  */
 async function refresh(): Promise<void> {
   try {
     await loadSettings();
   } catch (error) {
-    console.error('failed to reload Copy Selection settings after a failed write', error);
+    console.error('failed to reload Multiple Links settings after a failed write', error);
   }
 }
 
@@ -49,7 +50,7 @@ function wireBulletListMarker(): void {
     if (!(target instanceof HTMLInputElement) || !isBulletListMarker(target.value)) return;
 
     try {
-      await SelectionSettings.setBulletListMarker(target.value);
+      await MultipleLinksSettings.setBulletListMarker(target.value);
       hideFlash();
     } catch (error) {
       console.error('failed to save settings:', error);
@@ -59,16 +60,16 @@ function wireBulletListMarker(): void {
   });
 }
 
-function wireCodeBlockStyle(): void {
-  const form = document.forms.namedItem(CodeBlockStyleFormId);
+function wireTabGroupIndentation(): void {
+  const form = document.forms.namedItem(TabGroupIndentationFormId);
   if (!form) return;
 
   form.addEventListener('change', async (event) => {
     const target = event.target;
-    if (!(target instanceof HTMLInputElement) || !isCodeBlockStyle(target.value)) return;
+    if (!(target instanceof HTMLInputElement) || !isTabGroupIndentationStyle(target.value)) return;
 
     try {
-      await SelectionSettings.setCodeBlockStyle(target.value);
+      await MultipleLinksSettings.setTabGroupIndentation(target.value);
       hideFlash();
     } catch (error) {
       console.error('failed to save settings:', error);
@@ -84,9 +85,9 @@ function wireReset(): void {
 
   resetButton.addEventListener('click', async () => {
     try {
-      // Only this context: Multiple Links, menu visibility, Advanced, and every
+      // Only this context: Copy Selection, menu visibility, Advanced, and every
       // custom format are owned by their own pages and must survive this reset.
-      await resetSelectionSettings();
+      await resetMultipleLinksSettings();
       await loadSettings();
       hideFlash();
     } catch (error) {
@@ -99,11 +100,11 @@ function wireReset(): void {
 
 document.addEventListener('DOMContentLoaded', async () => {
   wireBulletListMarker();
-  wireCodeBlockStyle();
+  wireTabGroupIndentation();
   wireReset();
 
-  // Migrate before the first read so an upgrading profile that lands here never
-  // sees its preferences fall back to defaults.
+  // Migrate before the first read: this page may be the first one an upgrading
+  // profile opens.
   await ensureMarkdownSettingsMigrated();
 
   try {
@@ -113,10 +114,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     console.error('error getting settings', error);
     showFlash('Failed to load settings. Please try again.');
   }
+
+  const statuses = await loadPermissions();
+  hideUiIfPermissionsNotGranted(statuses);
+  disableUiIfPermissionsNotGranted(statuses);
 });
 
 browser.storage.sync.onChanged.addListener(async (changes) => {
-  const hasSettingsChanged = Object.keys(changes).some(key => SelectionSettings.keys.includes(key));
+  const hasSettingsChanged = Object.keys(changes).some(key => MultipleLinksSettings.keys.includes(key));
   if (hasSettingsChanged) {
     await refresh();
   }

--- a/test/e2e/formatting/options.spec.ts
+++ b/test/e2e/formatting/options.spec.ts
@@ -27,8 +27,8 @@ test.describe('Options Page - Clipboard Tests', () => {
       await page2.goto('http://localhost:5566/1.html');
       await page2.waitForLoadState('networkidle');
 
-      // Reset settings to default via options page
-      const optionsUrl = `chrome-extension://${extensionId}/dist/static/options.html`;
+      // Reset settings to default via the Multiple Links options page
+      const optionsUrl = `chrome-extension://${extensionId}/dist/static/multiple-links.html`;
       await page.goto(optionsUrl);
       await page.waitForLoadState('networkidle');
 
@@ -60,12 +60,12 @@ test.describe('Options Page - Clipboard Tests', () => {
       await page2.goto('http://localhost:5566/1.html');
       await page2.waitForLoadState('networkidle');
 
-      // Change setting to asterisk via options page
-      const optionsUrl = `chrome-extension://${extensionId}/dist/static/options.html`;
+      // Change setting to asterisk via the Multiple Links options page
+      const optionsUrl = `chrome-extension://${extensionId}/dist/static/multiple-links.html`;
       await page.goto(optionsUrl);
       await page.waitForLoadState('networkidle');
 
-      const asteriskRadio = page.locator('input[name="character"][value="asterisk"]');
+      const asteriskRadio = page.locator('input[name="bullet-list-marker"][value="*"]');
       await asteriskRadio.check();
       await page.waitForTimeout(500);
 
@@ -92,12 +92,12 @@ test.describe('Options Page - Clipboard Tests', () => {
       await page2.goto('http://localhost:5566/1.html');
       await page2.waitForLoadState('networkidle');
 
-      // Change setting to plus via options page
-      const optionsUrl = `chrome-extension://${extensionId}/dist/static/options.html`;
+      // Change setting to plus via the Multiple Links options page
+      const optionsUrl = `chrome-extension://${extensionId}/dist/static/multiple-links.html`;
       await page.goto(optionsUrl);
       await page.waitForLoadState('networkidle');
 
-      const plusRadio = page.locator('input[name="character"][value="plus"]');
+      const plusRadio = page.locator('input[name="bullet-list-marker"][value="+"]');
       await plusRadio.check();
       await page.waitForTimeout(500);
 
@@ -155,8 +155,8 @@ test.describe('Options Page - Clipboard Tests', () => {
         return;
       }
 
-      // Reset settings to default via options page
-      const optionsUrl = `chrome-extension://${extensionId}/dist/static/options.html`;
+      // Reset settings to default via the Multiple Links options page
+      const optionsUrl = `chrome-extension://${extensionId}/dist/static/multiple-links.html`;
       await page.goto(optionsUrl);
       await page.waitForLoadState('networkidle');
 
@@ -218,8 +218,8 @@ test.describe('Options Page - Clipboard Tests', () => {
         return;
       }
 
-      // Change setting to tab indentation via options page
-      const optionsUrl = `chrome-extension://${extensionId}/dist/static/options.html`;
+      // Change setting to tab indentation via the Multiple Links options page
+      const optionsUrl = `chrome-extension://${extensionId}/dist/static/multiple-links.html`;
       await page.goto(optionsUrl);
       await page.waitForLoadState('networkidle');
 

--- a/test/e2e/formatting/selection-as-markdown.spec.ts
+++ b/test/e2e/formatting/selection-as-markdown.spec.ts
@@ -203,7 +203,7 @@ test.describe('Selection as Markdown', () => {
       await optionsPage.goto(optionsUrl);
       await optionsPage.waitForLoadState('networkidle');
 
-      const asteriskRadio = optionsPage.locator('input[name="character"][value="asterisk"]');
+      const asteriskRadio = optionsPage.locator('input[name="bullet-list-marker"][value="*"]');
       await asteriskRadio.check();
       await optionsPage.waitForTimeout(500);
       await optionsPage.close();
@@ -244,7 +244,7 @@ test.describe('Selection as Markdown', () => {
       await optionsPage.goto(optionsUrl);
       await optionsPage.waitForLoadState('networkidle');
 
-      const plusRadio = optionsPage.locator('input[name="character"][value="plus"]');
+      const plusRadio = optionsPage.locator('input[name="bullet-list-marker"][value="+"]');
       await plusRadio.check();
       await optionsPage.waitForTimeout(500);
       await optionsPage.close();

--- a/test/e2e/formatting/settings-migration.spec.ts
+++ b/test/e2e/formatting/settings-migration.spec.ts
@@ -19,7 +19,6 @@ const __dirname = dirname(__filename);
 
 const LegacyUnorderedListKey = 'styleOfUnorderedList ';
 const LegacyCodeBlockKey = 'styleOfCodeBlock';
-const SelectionBulletKey = 'selection.markdown.bulletListMarker';
 
 const selectionCodeBlockLines = [
   'const greet = (name) => {',
@@ -105,9 +104,13 @@ test.describe('Markdown settings migration - output', () => {
     await seedStorage(serviceWorker, { [LegacyUnorderedListKey]: 'asterisk' });
     await migrateViaOptionsPage(context, extensionId);
 
-    // Diverge the two contexts the way the dedicated pages eventually will.
-    await seedStorage(serviceWorker, { [SelectionBulletKey]: '+' });
+    // Diverge the two contexts through the Copy Selection page itself.
+    const optionsPage = await context.newPage();
+    await optionsPage.goto(`chrome-extension://${extensionId}/dist/static/options.html`);
+    await optionsPage.waitForLoadState('networkidle');
+    await optionsPage.locator('input[name="bullet-list-marker"][value="+"]').check();
     await wait(500);
+    await optionsPage.close();
 
     // Multiple Links keeps the migrated asterisk...
     await page.goto('http://localhost:5566/0.html');

--- a/test/e2e/ui/advanced.spec.ts
+++ b/test/e2e/ui/advanced.spec.ts
@@ -60,12 +60,13 @@ test.describe('Advanced page', () => {
       await page.goto(url(extensionId, name));
       await page.waitForLoadState('networkidle');
 
-      const general = page.locator('#menu .menu-label', { hasText: 'General' }).locator('+ .menu-list');
+      const formats = page.locator('#menu .menu-label', { hasText: 'Formats' }).locator('+ .menu-list');
       const others = page.locator('#menu .menu-label', { hasText: 'Others' }).locator('+ .menu-list');
 
       await expect(others.locator('a[href="advanced.html"]')).toHaveCount(1);
       await expect(others.locator('a[href="options-permissions.html"]')).toHaveCount(1);
-      await expect(general.locator('a[href="options-permissions.html"]')).toHaveCount(0);
+      await expect(formats.locator('a[href="options-permissions.html"]')).toHaveCount(0);
+      await expect(formats.locator('a[href="advanced.html"]')).toHaveCount(0);
     });
   }
 
@@ -98,7 +99,12 @@ test.describe('Advanced page', () => {
   test('reset restores only link-text escaping', async ({ page, extensionId }) => {
     await page.goto(url(extensionId, 'options.html'));
     await page.waitForLoadState('networkidle');
-    await page.locator('input[name="character"][value="asterisk"]').check();
+    await page.locator('input[name="bullet-list-marker"][value="*"]').check();
+    await page.waitForTimeout(200);
+
+    await page.goto(url(extensionId, 'multiple-links.html'));
+    await page.waitForLoadState('networkidle');
+    await page.locator('input[name="bullet-list-marker"][value="*"]').check();
     await page.waitForTimeout(200);
     await page.locator('input[name="indentation"][value="tab"]').check();
     await page.waitForTimeout(200);
@@ -113,7 +119,7 @@ test.describe('Advanced page', () => {
 
     await expect(page.locator('input[name="enabled"]')).not.toBeChecked();
 
-    // The Markdown Style page's own settings survive untouched.
+    // The format pages' own settings survive untouched.
     expect(await readSync(page, [
       'selection.markdown.bulletListMarker',
       'multipleLinks.markdown.bulletListMarker',
@@ -125,25 +131,27 @@ test.describe('Advanced page', () => {
     });
   });
 
-  test('survives the Markdown Style page reset', async ({ page, extensionId }) => {
-    await page.goto(url(extensionId, 'advanced.html'));
-    await page.waitForLoadState('networkidle');
-    await page.locator('input[name="enabled"]').check();
-    await page.waitForTimeout(500);
+  for (const formatPage of ['options.html', 'multiple-links.html']) {
+    test(`survives the ${formatPage} reset`, async ({ page, extensionId }) => {
+      await page.goto(url(extensionId, 'advanced.html'));
+      await page.waitForLoadState('networkidle');
+      await page.locator('input[name="enabled"]').check();
+      await page.waitForTimeout(500);
 
-    await page.goto(url(extensionId, 'options.html'));
-    await page.waitForLoadState('networkidle');
-    await page.locator('input[name="character"][value="asterisk"]').check();
-    await page.waitForTimeout(200);
-    await page.locator('#reset').click();
-    await page.waitForTimeout(500);
+      await page.goto(url(extensionId, formatPage));
+      await page.waitForLoadState('networkidle');
+      await page.locator('input[name="bullet-list-marker"][value="*"]').check();
+      await page.waitForTimeout(200);
+      await page.locator('#reset').click();
+      await page.waitForTimeout(500);
 
-    await expect(page.locator('input[name="character"][value="dash"]')).toBeChecked();
+      await expect(page.locator('input[name="bullet-list-marker"][value="-"]')).toBeChecked();
 
-    await page.goto(url(extensionId, 'advanced.html'));
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator('input[name="enabled"]')).toBeChecked();
-  });
+      await page.goto(url(extensionId, 'advanced.html'));
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('input[name="enabled"]')).toBeChecked();
+    });
+  }
 
   test('survives revoking every permission', async ({ page, extensionId }) => {
     await page.goto(url(extensionId, 'advanced.html'));
@@ -153,7 +161,7 @@ test.describe('Advanced page', () => {
 
     await page.goto(url(extensionId, 'options.html'));
     await page.waitForLoadState('networkidle');
-    await page.locator('input[name="character"][value="asterisk"]').check();
+    await page.locator('input[name="bullet-list-marker"][value="*"]').check();
     await page.waitForTimeout(200);
 
     await page.goto(url(extensionId, 'menu-commands.html'));

--- a/test/e2e/ui/options.spec.ts
+++ b/test/e2e/ui/options.spec.ts
@@ -1,66 +1,137 @@
 /**
- * E2E tests for Options Page - UI Tests
+ * E2E tests for the format options pages - UI Tests
  *
- * Tests the settings UI persistence and reset functionality.
+ * Copy Selection and Multiple Links each own their formatting settings, so this
+ * covers persistence across reloads and that one page's reset never reaches into
+ * the other's settings.
  */
 
+import type { Page } from '@playwright/test';
 import { expect, test } from '../fixtures';
 
-test.describe('Options Page - UI Tests', () => {
-  test.describe('Settings Persistence', () => {
-    test('should persist settings across page reloads', async ({ page, extensionId }) => {
-      const optionsUrl = `chrome-extension://${extensionId}/dist/static/options.html`;
+function copySelectionUrl(extensionId: string): string {
+  return `chrome-extension://${extensionId}/dist/static/options.html`;
+}
 
-      // Set all settings to non-default values
-      await page.goto(optionsUrl);
-      await page.waitForLoadState('networkidle');
+function multipleLinksUrl(extensionId: string): string {
+  return `chrome-extension://${extensionId}/dist/static/multiple-links.html`;
+}
 
-      const asteriskRadio = page.locator('input[name="character"][value="asterisk"]');
-      await asteriskRadio.check();
-      await page.waitForTimeout(200);
+function marker(page: Page, value: string) {
+  return page.locator(`input[name="bullet-list-marker"][value="${value}"]`);
+}
 
-      const tabIndentationRadio = page.locator('input[name="indentation"][value="tab"]');
-      await tabIndentationRadio.check();
-      await page.waitForTimeout(200);
+async function open(page: Page, url: string): Promise<void> {
+  await page.goto(url);
+  await page.waitForLoadState('networkidle');
+}
 
-      // Reload the page
-      await page.reload();
-      await page.waitForLoadState('networkidle');
+test.describe('Format options pages - UI Tests', () => {
+  test('lands on Copy Selection when the options page is opened', async ({ page, extensionId }) => {
+    await open(page, copySelectionUrl(extensionId));
 
-      // Verify all settings persisted
-      const asteriskRadioAfter = page.locator('input[name="character"][value="asterisk"]');
-      await expect(asteriskRadioAfter).toBeChecked();
+    await expect(page.getByRole('heading', { name: /Copy Selection/ })).toBeVisible();
+    await expect(page.locator('#menu a.is-active')).toHaveText('Copy Selection');
+  });
 
-      const tabIndentationRadioAfter = page.locator('input[name="indentation"][value="tab"]');
-      await expect(tabIndentationRadioAfter).toBeChecked();
-    });
+  test('keeps Single Link blank with its custom formats and no reset', async ({ page, extensionId }) => {
+    await open(page, `chrome-extension://${extensionId}/dist/static/single-link.html`);
 
-    test('should reset all settings to default when reset button is clicked', async ({ page, extensionId }) => {
-      const optionsUrl = `chrome-extension://${extensionId}/dist/static/options.html`;
+    await expect(page.locator('#reset')).toHaveCount(0);
+    await expect(page.locator('input[name="bullet-list-marker"]')).toHaveCount(0);
+    await expect(
+      page.locator('[data-menu-custom-format-context="single-link"] [data-menu-custom-format-slot]'),
+    ).toHaveCount(5);
+  });
 
-      // Set all settings to non-default values
-      await page.goto(optionsUrl);
-      await page.waitForLoadState('networkidle');
+  test('persists each page\'s settings across reloads', async ({ page, extensionId }) => {
+    await open(page, copySelectionUrl(extensionId));
+    await marker(page, '*').check();
+    await page.locator('input[name="code-block-style"][value="indented"]').check();
+    await page.waitForTimeout(200);
 
-      const asteriskRadio = page.locator('input[name="character"][value="asterisk"]');
-      await asteriskRadio.check();
-      await page.waitForTimeout(200);
+    await open(page, multipleLinksUrl(extensionId));
+    await marker(page, '+').check();
+    await page.locator('input[name="indentation"][value="tab"]').check();
+    await page.waitForTimeout(200);
 
-      const tabIndentationRadio = page.locator('input[name="indentation"][value="tab"]');
-      await tabIndentationRadio.check();
-      await page.waitForTimeout(200);
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(marker(page, '+')).toBeChecked();
+    await expect(page.locator('input[name="indentation"][value="tab"]')).toBeChecked();
 
-      // Click reset button
-      const resetButton = page.locator('#reset');
-      await resetButton.click();
-      await page.waitForTimeout(500);
+    await open(page, copySelectionUrl(extensionId));
+    await expect(marker(page, '*')).toBeChecked();
+    await expect(page.locator('input[name="code-block-style"][value="indented"]')).toBeChecked();
+  });
 
-      // Verify all settings reset to defaults
-      const dashRadio = page.locator('input[name="character"][value="dash"]');
-      await expect(dashRadio).toBeChecked();
+  test('resets Copy Selection without touching Multiple Links', async ({ page, extensionId }) => {
+    await open(page, multipleLinksUrl(extensionId));
+    await marker(page, '+').check();
+    await page.waitForTimeout(200);
 
-      const spacesIndentationRadio = page.locator('input[name="indentation"][value="spaces"]');
-      await expect(spacesIndentationRadio).toBeChecked();
+    await open(page, copySelectionUrl(extensionId));
+    await marker(page, '*').check();
+    await page.locator('input[name="code-block-style"][value="indented"]').check();
+    await page.waitForTimeout(200);
+
+    await page.getByTestId('reset-copy-selection').click();
+    await page.waitForTimeout(500);
+
+    await expect(marker(page, '-')).toBeChecked();
+    await expect(page.locator('input[name="code-block-style"][value="fenced"]')).toBeChecked();
+
+    await open(page, multipleLinksUrl(extensionId));
+    await expect(marker(page, '+')).toBeChecked();
+  });
+
+  test('resets Multiple Links without touching Copy Selection', async ({ page, extensionId }) => {
+    await open(page, copySelectionUrl(extensionId));
+    await marker(page, '*').check();
+    await page.waitForTimeout(200);
+
+    await open(page, multipleLinksUrl(extensionId));
+    await marker(page, '+').check();
+    await page.locator('input[name="indentation"][value="tab"]').check();
+    await page.waitForTimeout(200);
+
+    await page.getByTestId('reset-multiple-links').click();
+    await page.waitForTimeout(500);
+
+    await expect(marker(page, '-')).toBeChecked();
+    await expect(page.locator('input[name="indentation"][value="spaces"]')).toBeChecked();
+
+    await open(page, copySelectionUrl(extensionId));
+    await expect(marker(page, '*')).toBeChecked();
+  });
+
+  test('leaves menu visibility and custom formats alone when a format page resets', async ({ page, extensionId }) => {
+    await open(page, `chrome-extension://${extensionId}/dist/static/menu-commands.html`);
+    await page.getByTestId('builtin-tabTitleList').uncheck();
+    await page.waitForTimeout(200);
+
+    await open(page, `chrome-extension://${extensionId}/dist/static/custom-format.html?context=multiple-links&slot=1`);
+    await page.locator('#input-name').fill('My Format');
+    await page.locator('#input-template').fill('{{title}}');
+    await page.locator('#save').click();
+    await page.waitForTimeout(500);
+
+    await open(page, copySelectionUrl(extensionId));
+    await page.getByTestId('reset-copy-selection').click();
+    await page.waitForTimeout(200);
+
+    await open(page, multipleLinksUrl(extensionId));
+    await page.getByTestId('reset-multiple-links').click();
+    await page.waitForTimeout(500);
+
+    expect(await page.evaluate(() => chrome.storage.sync.get([
+      'builtin.style.tabTitleList',
+      'custom_formats.multiple-links.1.name',
+      'custom_formats.multiple-links.1.template',
+    ]))).toEqual({
+      'builtin.style.tabTitleList': false,
+      'custom_formats.multiple-links.1.name': 'My Format',
+      'custom_formats.multiple-links.1.template': '{{title}}',
     });
   });
 });

--- a/test/e2e/ui/settings-migration.spec.ts
+++ b/test/e2e/ui/settings-migration.spec.ts
@@ -82,8 +82,40 @@ test.describe('Markdown settings migration', () => {
     await optionsPage.reload();
     await optionsPage.waitForLoadState('networkidle');
 
-    await expect(optionsPage.locator('input[name="character"][value="plus"]')).toBeChecked();
+    await expect(optionsPage.locator('input[name="bullet-list-marker"][value="+"]')).toBeChecked();
     await expect(optionsPage.locator('input[name="code-block-style"][value="indented"]')).toBeChecked();
     await optionsPage.close();
+  });
+
+  test('starts both format pages on the migrated marker, then lets them diverge', async ({ context, extensionId }) => {
+    await seedStorage(serviceWorker, { [LegacyUnorderedListKey]: 'asterisk' });
+
+    const copySelectionPage = await context.newPage();
+    await copySelectionPage.goto(optionsUrlOf(extensionId));
+    await copySelectionPage.waitForLoadState('networkidle');
+    await wait(500);
+    await expect(copySelectionPage.locator('input[name="bullet-list-marker"][value="*"]')).toBeChecked();
+
+    const multipleLinksPage = await context.newPage();
+    await multipleLinksPage.goto(`chrome-extension://${extensionId}/dist/static/multiple-links.html`);
+    await multipleLinksPage.waitForLoadState('networkidle');
+    await wait(500);
+    // Both contexts inherited the one legacy choice, so nothing changed on upgrade.
+    await expect(multipleLinksPage.locator('input[name="bullet-list-marker"][value="*"]')).toBeChecked();
+
+    // Changing one context leaves the other where the migration put it.
+    await copySelectionPage.locator('input[name="bullet-list-marker"][value="+"]').check();
+    await wait(500);
+
+    await multipleLinksPage.reload();
+    await multipleLinksPage.waitForLoadState('networkidle');
+    await expect(multipleLinksPage.locator('input[name="bullet-list-marker"][value="*"]')).toBeChecked();
+
+    const stored = await readStorage(serviceWorker);
+    expect(stored[SelectionBulletKey]).toBe('+');
+    expect(stored[MultipleLinksBulletKey]).toBe('*');
+
+    await copySelectionPage.close();
+    await multipleLinksPage.close();
   });
 });

--- a/test/markdown-settings.test.ts
+++ b/test/markdown-settings.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { MarkdownSettings } from '../src/lib/markdown-settings';
 import {
   loadMarkdownSettings,
   readMarkdownSettings,
-  resetMarkdownSettings,
-  setSharedBulletListMarker,
+  resetMultipleLinksSettings,
+  resetSelectionSettings,
 } from '../src/lib/markdown-settings';
 import { LegacyMarkdownSettingKeys } from '../src/lib/markdown-settings-migration';
 import type { FakeSyncStorage } from './support/fake-sync-storage';
@@ -89,87 +90,125 @@ describe('markdown settings', () => {
     });
   });
 
-  describe('setSharedBulletListMarker() — one control, two contexts', () => {
-    it('points both contexts at the marker', async () => {
-      await setSharedBulletListMarker('+');
-
-      expect(storage.data['selection.markdown.bulletListMarker']).toBe('+');
-      expect(storage.data['multipleLinks.markdown.bulletListMarker']).toBe('+');
-    });
-
-    it('cannot half-succeed and leave the contexts disagreeing', async () => {
-      await setSharedBulletListMarker('*');
-      storage.failNextSet = new Error('QUOTA_BYTES quota exceeded');
-
-      await expect(setSharedBulletListMarker('+')).rejects.toThrow();
-
-      // Both keys still hold the previous choice — no split behind one control.
-      expect(storage.data['selection.markdown.bulletListMarker']).toBe('*');
-      expect(storage.data['multipleLinks.markdown.bulletListMarker']).toBe('*');
-    });
-  });
-
-  describe('resetMarkdownSettings() — the Markdown Style page reset', () => {
-    it('restores every setting the page owns', async () => {
+  describe('page-owned resets', () => {
+    it('lets the Copy Selection reset restore only its own settings', async () => {
       storage.data['selection.markdown.bulletListMarker'] = '+';
       storage.data['selection.markdown.codeBlockStyle'] = 'indented';
       storage.data['multipleLinks.markdown.bulletListMarker'] = '*';
       storage.data['multipleLinks.markdown.tabGroupIndentation'] = 'tab';
-
-      await resetMarkdownSettings();
-
-      expect(await readMarkdownSettings()).toEqual({
-        alwaysEscapeLinkBrackets: false,
-        selection: { bulletListMarker: '-', codeBlockStyle: 'fenced' },
-        multipleLinks: { bulletListMarker: '-', tabGroupIndentation: 'spaces' },
-      });
-    });
-
-    it('leaves link-text escaping to the Advanced page', async () => {
       storage.data.linkTextAlwaysEscapeBrackets = true;
-
-      await resetMarkdownSettings();
-
-      expect(storage.data.linkTextAlwaysEscapeBrackets).toBe(true);
-    });
-
-    it('cannot reset some contexts and not others', async () => {
-      storage.data['selection.markdown.bulletListMarker'] = '+';
-      storage.data['multipleLinks.markdown.bulletListMarker'] = '*';
-      storage.failNextRemove = new Error('storage unavailable');
-
-      await expect(resetMarkdownSettings()).rejects.toThrow();
-
-      expect(storage.data['selection.markdown.bulletListMarker']).toBe('+');
-      expect(storage.data['multipleLinks.markdown.bulletListMarker']).toBe('*');
-    });
-
-    it('does not let a legacy value retained by a failed cleanup resurrect', async () => {
-      storage.data[LegacyMarkdownSettingKeys.unorderedList] = 'asterisk';
-      storage.failNextRemove = new Error('storage unavailable');
-      await loadMarkdownSettings();
-      // The failed cleanup left the legacy key in place for a later retry.
-      expect(storage.data[LegacyMarkdownSettingKeys.unorderedList]).toBe('asterisk');
-
-      await resetMarkdownSettings();
-
-      // The next startup must not migrate the old value back over the defaults.
-      expect(await loadMarkdownSettings()).toEqual({
-        alwaysEscapeLinkBrackets: false,
-        selection: { bulletListMarker: '-', codeBlockStyle: 'fenced' },
-        multipleLinks: { bulletListMarker: '-', tabGroupIndentation: 'spaces' },
-      });
-      expect(storage.data[LegacyMarkdownSettingKeys.unorderedList]).toBeUndefined();
-    });
-
-    it('leaves custom formats alone', async () => {
       storage.data['custom_formats.multiple-links.1.name'] = 'My Format';
       storage.data['custom_formats.multiple-links.1.template'] = '{{title}}';
 
-      await resetMarkdownSettings();
+      await resetSelectionSettings();
 
+      expect(await readMarkdownSettings()).toEqual({
+        alwaysEscapeLinkBrackets: true,
+        selection: { bulletListMarker: '-', codeBlockStyle: 'fenced' },
+        multipleLinks: { bulletListMarker: '*', tabGroupIndentation: 'tab' },
+      });
       expect(storage.data['custom_formats.multiple-links.1.name']).toBe('My Format');
       expect(storage.data['custom_formats.multiple-links.1.template']).toBe('{{title}}');
+    });
+
+    it('lets the Multiple Links reset restore only its own settings', async () => {
+      storage.data['selection.markdown.bulletListMarker'] = '+';
+      storage.data['selection.markdown.codeBlockStyle'] = 'indented';
+      storage.data['multipleLinks.markdown.bulletListMarker'] = '*';
+      storage.data['multipleLinks.markdown.tabGroupIndentation'] = 'tab';
+      storage.data.linkTextAlwaysEscapeBrackets = true;
+
+      await resetMultipleLinksSettings();
+
+      expect(await readMarkdownSettings()).toEqual({
+        alwaysEscapeLinkBrackets: true,
+        selection: { bulletListMarker: '+', codeBlockStyle: 'indented' },
+        multipleLinks: { bulletListMarker: '-', tabGroupIndentation: 'spaces' },
+      });
+    });
+
+    it.each([
+      ['Copy Selection', resetSelectionSettings, (s: MarkdownSettings) => s.selection.bulletListMarker],
+      ['Multiple Links', resetMultipleLinksSettings, (s: MarkdownSettings) => s.multipleLinks.bulletListMarker],
+    ])('keeps a %s reset final even when a legacy key survived a failed cleanup', async (_context, reset, markerOf) => {
+      storage.data[LegacyMarkdownSettingKeys.unorderedList] = 'asterisk';
+      storage.failNextRemove = new Error('storage unavailable');
+      await loadMarkdownSettings();
+      // The failed cleanup left the legacy key in place for a later retry, but
+      // both contexts already hold their migrated copy.
+      expect(storage.data[LegacyMarkdownSettingKeys.unorderedList]).toBe('asterisk');
+
+      await reset();
+
+      // Spent everywhere, so the reset retires it: the next startup cannot
+      // migrate it back over the default the user just asked for.
+      expect(storage.data[LegacyMarkdownSettingKeys.unorderedList]).toBeUndefined();
+      expect(markerOf(await loadMarkdownSettings())).toBe('-');
+    });
+
+    it.each([
+      [
+        'Copy Selection',
+        resetSelectionSettings,
+        (s: MarkdownSettings) => s.selection.bulletListMarker,
+        (s: MarkdownSettings) => s.multipleLinks.bulletListMarker,
+      ],
+      [
+        'Multiple Links',
+        resetMultipleLinksSettings,
+        (s: MarkdownSettings) => s.multipleLinks.bulletListMarker,
+        (s: MarkdownSettings) => s.selection.bulletListMarker,
+      ],
+    ])(
+      'does not spend the shared legacy marker when a %s reset follows a failed migration write',
+      async (_context, reset, ownMarkerOf, siblingMarkerOf) => {
+        storage.data[LegacyMarkdownSettingKeys.unorderedList] = 'asterisk';
+        storage.failNextSet = new Error('QUOTA_BYTES quota exceeded');
+        await loadMarkdownSettings();
+        // Nothing materialized: the legacy key is still both contexts' only copy.
+        expect(storage.data['selection.markdown.bulletListMarker']).toBeUndefined();
+        expect(storage.data['multipleLinks.markdown.bulletListMarker']).toBeUndefined();
+
+        await reset();
+
+        // The sibling's preference survives the retry...
+        const migrated = await loadMarkdownSettings();
+        expect(siblingMarkerOf(migrated)).toBe('*');
+        // ...while the reset context keeps the default it was just given.
+        expect(ownMarkerOf(migrated)).toBe('-');
+      },
+    );
+
+    it('keeps the shared legacy marker for the sibling when the reset cannot migrate it', async () => {
+      storage.data[LegacyMarkdownSettingKeys.unorderedList] = 'asterisk';
+      storage.data[LegacyMarkdownSettingKeys.codeBlock] = 'indented';
+      // The migration the reset runs first cannot materialize either context.
+      storage.failNextSet = new Error('QUOTA_BYTES quota exceeded');
+
+      await resetSelectionSettings();
+
+      // Still the only copy of the sibling's preference, so it stays...
+      expect(storage.data[LegacyMarkdownSettingKeys.unorderedList]).toBe('asterisk');
+      // ...and Copy Selection records its defaults instead, which a later
+      // migration will not overwrite.
+      expect(storage.data['selection.markdown.bulletListMarker']).toBe('-');
+      expect(storage.data['selection.markdown.codeBlockStyle']).toBe('fenced');
+
+      const migrated = await loadMarkdownSettings();
+      expect(migrated.multipleLinks.bulletListMarker).toBe('*');
+      expect(migrated.selection).toEqual({ bulletListMarker: '-', codeBlockStyle: 'fenced' });
+    });
+
+    it('does not spend the shared legacy marker for a sibling value it cannot read', async () => {
+      storage.data[LegacyMarkdownSettingKeys.unorderedList] = 'asterisk';
+      // Written by a newer version: present, but not a marker this version knows.
+      storage.data['multipleLinks.markdown.bulletListMarker'] = 'em-dash';
+
+      await resetSelectionSettings();
+
+      expect(storage.data[LegacyMarkdownSettingKeys.unorderedList]).toBe('asterisk');
+      expect(storage.data['multipleLinks.markdown.bulletListMarker']).toBe('em-dash');
+      expect((await readMarkdownSettings()).selection.bulletListMarker).toBe('-');
     });
   });
 

--- a/test/multiple-links-settings.test.ts
+++ b/test/multiple-links-settings.test.ts
@@ -65,22 +65,6 @@ describe('multiple links settings', () => {
     });
   });
 
-  describe('reset()', () => {
-    it('restores the defaults and touches nothing else', async () => {
-      storage.data[MultipleLinksSettingKeys.bulletListMarker] = '*';
-      storage.data[MultipleLinksSettingKeys.tabGroupIndentation] = 'tab';
-      storage.data['selection.markdown.bulletListMarker'] = '+';
-
-      await MultipleLinksSettings.reset();
-
-      expect(await MultipleLinksSettings.getAll()).toEqual({
-        bulletListMarker: '-',
-        tabGroupIndentation: TabGroupIndentationStyle.Spaces,
-      });
-      expect(storage.data['selection.markdown.bulletListMarker']).toBe('+');
-    });
-  });
-
   it('owns the documented storage keys', () => {
     expect(MultipleLinksSettings.keys).toEqual([
       'multipleLinks.markdown.bulletListMarker',

--- a/test/selection-settings.test.ts
+++ b/test/selection-settings.test.ts
@@ -64,22 +64,6 @@ describe('selection settings', () => {
     });
   });
 
-  describe('reset()', () => {
-    it('restores the defaults and touches nothing else', async () => {
-      storage.data[SelectionSettingKeys.bulletListMarker] = '*';
-      storage.data[SelectionSettingKeys.codeBlockStyle] = 'indented';
-      storage.data['multipleLinks.markdown.bulletListMarker'] = '+';
-
-      await SelectionSettings.reset();
-
-      expect(await SelectionSettings.getAll()).toEqual({
-        bulletListMarker: '-',
-        codeBlockStyle: 'fenced',
-      });
-      expect(storage.data['multipleLinks.markdown.bulletListMarker']).toBe('+');
-    });
-  });
-
   it('owns the documented storage keys', () => {
     expect(SelectionSettings.keys).toEqual([
       'selection.markdown.bulletListMarker',

--- a/test/ui/multiple-links.spec.ts
+++ b/test/ui/multiple-links.spec.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+
+const multipleLinksSettingsMock = {
+  keys: ['multipleLinks.markdown.bulletListMarker', 'multipleLinks.markdown.tabGroupIndentation'],
+  getAll: vi.fn(),
+  setBulletListMarker: vi.fn(),
+  setTabGroupIndentation: vi.fn(),
+};
+
+const ensureMarkdownSettingsMigratedMock = vi.fn();
+const resetMultipleLinksSettingsMock = vi.fn();
+const loadPermissionsMock = vi.fn();
+
+const PermissionStatusValue = {
+  Yes: 'yes',
+  No: 'no',
+  Unavailable: 'unavailable',
+} as const;
+
+vi.mock('../../src/lib/multiple-links-settings.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/lib/multiple-links-settings.js')>();
+  return {
+    ...actual,
+    default: multipleLinksSettingsMock,
+  };
+});
+
+vi.mock('../../src/lib/markdown-settings.js', () => ({
+  ensureMarkdownSettingsMigrated: ensureMarkdownSettingsMigratedMock,
+  resetMultipleLinksSettings: resetMultipleLinksSettingsMock,
+}));
+
+vi.mock('../../src/ui/permissions-ui.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/ui/permissions-ui.js')>();
+  return {
+    ...actual,
+    loadPermissions: loadPermissionsMock,
+  };
+});
+
+async function loadPage(): Promise<void> {
+  const response = await fetch('/src/static/multiple-links.html');
+  const html = await response.text();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  document.documentElement.innerHTML = doc.documentElement.innerHTML;
+}
+
+function mockBrowser(): void {
+  (globalThis as any).browser = {
+    storage: { sync: { onChanged: { addListener: vi.fn() } } },
+  };
+}
+
+function flush(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function startPage(): Promise<void> {
+  await import('../../src/ui/multiple-links.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await flush();
+}
+
+describe('multiple links options page', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockBrowser();
+    ensureMarkdownSettingsMigratedMock.mockResolvedValue(undefined);
+    loadPermissionsMock.mockResolvedValue(new Map([['tabGroups', PermissionStatusValue.Yes]]));
+    multipleLinksSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '-', tabGroupIndentation: 'spaces' });
+    multipleLinksSettingsMock.setBulletListMarker.mockResolvedValue(undefined);
+    multipleLinksSettingsMock.setTabGroupIndentation.mockResolvedValue(undefined);
+    resetMultipleLinksSettingsMock.mockResolvedValue(undefined);
+    await loadPage();
+  });
+
+  it('owns only the Multiple Links controls', async () => {
+    await startPage();
+
+    await expect.element(page.getByRole('heading', { name: /Multiple Links/ })).toBeVisible();
+    expect(document.querySelector('#form-multiple-links-bullet-list-marker')).not.toBeNull();
+    expect(document.querySelector('#form-multiple-links-tab-group-indentation')).not.toBeNull();
+    // Code-block style belongs to Copy Selection, escaping to Advanced, and
+    // command visibility to Menu Commands.
+    expect(document.querySelector('[name="code-block-style"]')).toBeNull();
+    expect(document.querySelector('#form-link-text-always-escape-brackets')).toBeNull();
+    expect(document.querySelector('[data-built-in-style]')).toBeNull();
+  });
+
+  it('keeps its custom format child links', async () => {
+    await startPage();
+
+    const slots = document.querySelectorAll('[data-menu-custom-format-context="multiple-links"] [data-menu-custom-format-slot]');
+    expect(slots).toHaveLength(5);
+  });
+
+  it('migrates a legacy profile before its first read', async () => {
+    const order: string[] = [];
+    ensureMarkdownSettingsMigratedMock.mockImplementation(async () => {
+      order.push('migrate');
+    });
+    multipleLinksSettingsMock.getAll.mockImplementation(async () => {
+      order.push('read');
+      return { bulletListMarker: '*', tabGroupIndentation: 'spaces' };
+    });
+
+    await startPage();
+
+    expect(order[0]).toBe('migrate');
+    expect(order).toContain('read');
+  });
+
+  it('loads the persisted settings into the controls', async () => {
+    multipleLinksSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '*', tabGroupIndentation: 'tab' });
+
+    await startPage();
+
+    await expect.element(page.getByRole('radio', { name: /Asterisks/ })).toBeChecked();
+    await expect.element(page.getByRole('radio', { name: /^Tab$/ })).toBeChecked();
+  });
+
+  it('saves the bullet list marker to the Multiple Links context only', async () => {
+    await startPage();
+
+    await page.getByRole('radio', { name: /Plus Signs/ }).click();
+    await vi.waitFor(() => expect(multipleLinksSettingsMock.setBulletListMarker).toHaveBeenCalledWith('+'));
+    await expect.element(page.getByTestId('flash-error')).not.toBeVisible();
+  });
+
+  it('saves the tab group indentation', async () => {
+    await startPage();
+
+    await page.getByRole('radio', { name: /^Tab$/ }).click();
+    await vi.waitFor(() => expect(multipleLinksSettingsMock.setTabGroupIndentation).toHaveBeenCalledWith('tab'));
+  });
+
+  it('shows the persisted value and flashes when a save fails', async () => {
+    await startPage();
+    multipleLinksSettingsMock.setBulletListMarker.mockRejectedValueOnce(new Error('fail'));
+    multipleLinksSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '*', tabGroupIndentation: 'spaces' });
+
+    await page.getByRole('radio', { name: /Plus Signs/ }).click();
+    await flush();
+
+    await expect.element(page.getByRole('radio', { name: /Asterisks/ })).toBeChecked();
+    await expect.element(page.getByTestId('flash-error')).toBeVisible();
+  });
+
+  it('resets only the Multiple Links context', async () => {
+    multipleLinksSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '*', tabGroupIndentation: 'tab' });
+    await startPage();
+    multipleLinksSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '-', tabGroupIndentation: 'spaces' });
+
+    await page.getByTestId('reset-multiple-links').click();
+    await vi.waitFor(() => expect(resetMultipleLinksSettingsMock).toHaveBeenCalledTimes(1));
+    await expect.element(page.getByRole('radio', { name: /Dashes/ })).toBeChecked();
+    await expect.element(page.getByRole('radio', { name: /^Spaces$/ })).toBeChecked();
+  });
+
+  it('flashes and shows the persisted values when a reset fails', async () => {
+    multipleLinksSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '*', tabGroupIndentation: 'tab' });
+    await startPage();
+    resetMultipleLinksSettingsMock.mockRejectedValueOnce(new Error('fail'));
+
+    await page.getByTestId('reset-multiple-links').click();
+    await flush();
+
+    await expect.element(page.getByRole('radio', { name: /Asterisks/ })).toBeChecked();
+    await expect.element(page.getByTestId('flash-error')).toBeVisible();
+  });
+
+  it('disables the tab group indentation controls without the tabGroups permission', async () => {
+    loadPermissionsMock.mockResolvedValue(new Map([['tabGroups', PermissionStatusValue.No]]));
+
+    await startPage();
+    await flush();
+
+    await expect.element(page.getByRole('radio', { name: /^Spaces$/ })).toBeDisabled();
+    await expect.element(page.getByRole('radio', { name: /^Tab$/ })).toBeDisabled();
+    await expect.element(page.getByTestId('requires-permissions-tab-groups')).not.toHaveClass('is-hidden');
+  });
+
+  it('enables the tab group indentation controls when the permission is granted', async () => {
+    await startPage();
+    await flush();
+
+    await expect.element(page.getByRole('radio', { name: /^Spaces$/ })).toBeEnabled();
+    await expect.element(page.getByTestId('requires-permissions-tab-groups')).toHaveClass('is-hidden');
+  });
+});

--- a/test/ui/options.spec.ts
+++ b/test/ui/options.spec.ts
@@ -1,218 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 const selectionSettingsMock = {
+  keys: ['selection.markdown.bulletListMarker', 'selection.markdown.codeBlockStyle'],
+  getAll: vi.fn(),
   setBulletListMarker: vi.fn(),
   setCodeBlockStyle: vi.fn(),
-  reset: vi.fn(),
-  keys: [],
 };
 
-const multipleLinksSettingsMock = {
-  setBulletListMarker: vi.fn(),
-  setTabGroupIndentation: vi.fn(),
-  reset: vi.fn(),
-  keys: [],
-};
+const ensureMarkdownSettingsMigratedMock = vi.fn();
+const resetSelectionSettingsMock = vi.fn();
 
-const readMarkdownSettingsMock = vi.fn();
-const loadMarkdownSettingsMock = vi.fn();
-const setSharedBulletListMarkerMock = vi.fn();
-const resetMarkdownSettingsMock = vi.fn();
-
-const loadPermissionsMock = vi.fn();
-const PermissionStatusValue = {
-  Yes: 'yes',
-  No: 'no',
-  Unavailable: 'unavailable',
-} as const;
-
-vi.mock('../../src/lib/selection-settings.js', () => ({
-  default: selectionSettingsMock,
-}));
-
-vi.mock('../../src/lib/multiple-links-settings.js', () => ({
-  default: multipleLinksSettingsMock,
-}));
-
-vi.mock('../../src/lib/markdown-settings.js', () => ({
-  contextMarkdownSettingsKeys: [],
-  readMarkdownSettings: readMarkdownSettingsMock,
-  loadMarkdownSettings: loadMarkdownSettingsMock,
-  setSharedBulletListMarker: setSharedBulletListMarkerMock,
-  resetMarkdownSettings: resetMarkdownSettingsMock,
-}));
-
-// Mock the permissions UI module
-vi.mock('../../src/ui/permissions-ui.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../src/ui/permissions-ui.js')>();
+vi.mock('../../src/lib/selection-settings.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/lib/selection-settings.js')>();
   return {
     ...actual,
-    loadPermissions: loadPermissionsMock,
+    default: selectionSettingsMock,
   };
 });
 
-async function loadOptionsHtml(): Promise<void> {
+vi.mock('../../src/lib/markdown-settings.js', () => ({
+  ensureMarkdownSettingsMigrated: ensureMarkdownSettingsMigratedMock,
+  resetSelectionSettings: resetSelectionSettingsMock,
+}));
+
+async function loadPage(): Promise<void> {
   const response = await fetch('/src/static/options.html');
   const html = await response.text();
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
-  document.head.innerHTML = doc.head.innerHTML;
-  document.body.innerHTML = doc.body.innerHTML;
+  document.documentElement.innerHTML = doc.documentElement.innerHTML;
 }
 
-function mockBrowser() {
+function mockBrowser(): void {
   (globalThis as any).browser = {
     storage: { sync: { onChanged: { addListener: vi.fn() } } },
   };
 }
 
-async function flush(): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, 100));
+function flush(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
 }
 
-describe('options UI - with permissions granted', () => {
-  beforeAll(async () => {
-    // Set up environment before loading the module
-    await loadOptionsHtml();
+async function startPage(): Promise<void> {
+  await import('../../src/ui/options.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  await flush();
+}
+
+describe('copy selection options page', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
     mockBrowser();
-
-    // Set up initial mock responses
-    const settings = {
-      alwaysEscapeLinkBrackets: true,
-      selection: { bulletListMarker: '*', codeBlockStyle: 'indented' },
-      multipleLinks: { bulletListMarker: '*', tabGroupIndentation: 'tab' },
-    };
-    readMarkdownSettingsMock.mockResolvedValue(settings);
-    loadMarkdownSettingsMock.mockResolvedValue(settings);
-    loadPermissionsMock.mockResolvedValue(new Map([['tabGroups', PermissionStatusValue.Yes]]));
-
-    // Load the options module - this will register DOM event listeners
-    await import('../../src/ui/options.js');
-
-    // Trigger initialization
-    document.dispatchEvent(new Event('DOMContentLoaded'));
-    await flush();
+    ensureMarkdownSettingsMigratedMock.mockResolvedValue(undefined);
+    selectionSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '-', codeBlockStyle: 'fenced' });
+    selectionSettingsMock.setBulletListMarker.mockResolvedValue(undefined);
+    selectionSettingsMock.setCodeBlockStyle.mockResolvedValue(undefined);
+    resetSelectionSettingsMock.mockResolvedValue(undefined);
+    await loadPage();
   });
 
-  it('loads settings into the form', async () => {
-    const asteriskRadio = page.getByRole('radio', { name: /Asterisks/ });
-    await expect.element(asteriskRadio).toBeChecked();
+  it('is the landing page for Copy Selection and owns only its own controls', async () => {
+    await startPage();
 
-    const tabRadio = page.getByRole('radio', { name: /^Tab$/ });
-    await expect.element(tabRadio).toBeChecked();
-
-    const indentedCodeBlockRadio = page.getByRole('radio', { name: /Indented code block/ });
-    await expect.element(indentedCodeBlockRadio).toBeChecked();
-  });
-
-  it('enables tab group indentation when permission is granted', async () => {
-    // Verify that tab group indentation options are enabled when permission is granted
-    const spacesRadio = page.getByRole('radio', { name: /^Spaces$/ });
-    await expect.element(spacesRadio).toBeEnabled();
-
-    const tabRadio = page.getByRole('radio', { name: /^Tab$/ });
-    await expect.element(tabRadio).toBeEnabled();
-  });
-
-  it('hides or shows permission badges based on permissions', async () => {
-    // The tag should be hidden when tabGroups permission is granted (has is-hidden class)
-    await expect.element(page.getByTestId('requires-permissions-tab-groups')).to.toHaveClass('is-hidden');
-  });
-
-  it('no longer presents the link-text escaping control', async () => {
+    await expect.element(page.getByRole('heading', { name: /Copy Selection/ })).toBeVisible();
+    // Tab group indentation belongs to Multiple Links, escaping to Advanced.
+    expect(document.querySelector('#form-multiple-links-tab-group-indentation')).toBeNull();
+    expect(document.querySelector('[name="indentation"]')).toBeNull();
     expect(document.querySelector('#form-link-text-always-escape-brackets')).toBeNull();
   });
 
-  it('writes the bullet list marker for both contexts in one save', async () => {
-    setSharedBulletListMarkerMock.mockClear();
-    setSharedBulletListMarkerMock.mockResolvedValue(undefined);
+  it('lists the pages under Formats and Others', async () => {
+    await startPage();
 
-    const plusRadio = page.getByRole('radio', { name: /Plus Signs/ });
-    await expect.element(plusRadio).toBeInTheDocument();
+    const menu = document.querySelector('#menu')!;
+    const labels = [...menu.querySelectorAll('.menu-label')].map(el => el.textContent?.trim());
+    expect(labels).toEqual(['Formats', 'Others']);
 
-    await plusRadio.click();
-
-    expect(setSharedBulletListMarkerMock).toHaveBeenCalledWith('+');
-    expect(setSharedBulletListMarkerMock).toHaveBeenCalledTimes(1);
+    const links = [...menu.querySelectorAll('a')]
+      .filter(a => !a.dataset.menuCustomFormatSlot)
+      .map(a => a.textContent?.trim());
+    expect(links).toEqual([
+      'Copy Selection',
+      'Multiple Links',
+      'Single Link',
+      'Menu Commands',
+      'Advanced',
+      'Permissions',
+      'Help & Examples',
+      'About',
+    ]);
   });
 
-  it('shows flash on save failure', async () => {
-    setSharedBulletListMarkerMock.mockClear();
-    setSharedBulletListMarkerMock.mockRejectedValueOnce(new Error('fail'));
+  it('migrates a legacy profile before its first read', async () => {
+    const order: string[] = [];
+    ensureMarkdownSettingsMigratedMock.mockImplementation(async () => {
+      order.push('migrate');
+    });
+    selectionSettingsMock.getAll.mockImplementation(async () => {
+      order.push('read');
+      return { bulletListMarker: '*', codeBlockStyle: 'fenced' };
+    });
 
-    const dashRadio = page.getByRole('radio', { name: /Dashes/ });
-    await expect.element(dashRadio).toBeInTheDocument();
+    await startPage();
 
-    await dashRadio.click();
-
-    expect(setSharedBulletListMarkerMock).toHaveBeenCalled();
-
-    const flash = page.getByTestId('flash-error');
-    await expect.element(flash).toBeVisible();
+    expect(order[0]).toBe('migrate');
+    expect(order).toContain('read');
   });
 
-  it('saves code block style on change', async () => {
-    selectionSettingsMock.setCodeBlockStyle.mockClear();
-    selectionSettingsMock.setCodeBlockStyle.mockResolvedValue(undefined);
+  it('loads the persisted settings into the controls', async () => {
+    selectionSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '*', codeBlockStyle: 'indented' });
 
-    const fencedRadio = page.getByRole('radio', { name: /Fenced code block/ });
-    await expect.element(fencedRadio).toBeInTheDocument();
+    await startPage();
 
-    await fencedRadio.click();
-
-    expect(selectionSettingsMock.setCodeBlockStyle).toHaveBeenCalledWith('fenced');
+    await expect.element(page.getByRole('radio', { name: /Asterisks/ })).toBeChecked();
+    await expect.element(page.getByRole('radio', { name: /Indented code block/ })).toBeChecked();
   });
 
-  it('saves tab group indentation to the Multiple Links context', async () => {
-    multipleLinksSettingsMock.setTabGroupIndentation.mockClear();
-    multipleLinksSettingsMock.setTabGroupIndentation.mockResolvedValue(undefined);
+  it('saves the bullet list marker to the Copy Selection context only', async () => {
+    await startPage();
 
-    const spacesRadio = page.getByRole('radio', { name: /^Spaces$/ });
-    await expect.element(spacesRadio).toBeInTheDocument();
-
-    await spacesRadio.click();
-
-    expect(multipleLinksSettingsMock.setTabGroupIndentation).toHaveBeenCalledWith('spaces');
+    await page.getByRole('radio', { name: /Plus Signs/ }).click();
+    await vi.waitFor(() => expect(selectionSettingsMock.setBulletListMarker).toHaveBeenCalledWith('+'));
+    await expect.element(page.getByTestId('flash-error')).not.toBeVisible();
   });
 
-  it('resets every context the combined page still owns, in one removal', async () => {
-    resetMarkdownSettingsMock.mockClear().mockResolvedValue(undefined);
+  it('saves the code block style', async () => {
+    await startPage();
 
-    const resetButton = page.getByRole('button', { name: /Restore to Default/ });
-    await resetButton.click();
-
-    expect(resetMarkdownSettingsMock).toHaveBeenCalledTimes(1);
+    await page.getByRole('radio', { name: /Indented code block/ }).click();
+    await vi.waitFor(() => expect(selectionSettingsMock.setCodeBlockStyle).toHaveBeenCalledWith('indented'));
   });
-});
 
-describe('options UI - with permissions denied', () => {
-  beforeAll(async () => {
-    // Reset DOM and set up a new scenario
-    await loadOptionsHtml();
-    mockBrowser();
+  it('shows the persisted value and flashes when a save fails', async () => {
+    await startPage();
+    selectionSettingsMock.setBulletListMarker.mockRejectedValueOnce(new Error('fail'));
+    // Another page changed it in the meantime: the failed save must show what is
+    // actually persisted, not simply undo the click.
+    selectionSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '*', codeBlockStyle: 'fenced' });
 
-    // Set up mock responses with permissions denied
-    const settings = {
-      alwaysEscapeLinkBrackets: false,
-      selection: { bulletListMarker: '-', codeBlockStyle: 'fenced' },
-      multipleLinks: { bulletListMarker: '-', tabGroupIndentation: 'spaces' },
-    };
-    readMarkdownSettingsMock.mockResolvedValue(settings);
-    loadMarkdownSettingsMock.mockResolvedValue(settings);
-    loadPermissionsMock.mockResolvedValue(new Map([['tabGroups', PermissionStatusValue.No]]));
-
-    // Since module is already loaded, we trigger DOMContentLoaded again
-    // The module's event listener will fire again
-    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await page.getByRole('radio', { name: /Plus Signs/ }).click();
     await flush();
+
+    await expect.element(page.getByRole('radio', { name: /Asterisks/ })).toBeChecked();
+    await expect.element(page.getByTestId('flash-error')).toBeVisible();
   });
 
-  it('disables tab group indentation when permission not granted', async () => {
-    const spacesRadio = page.getByRole('radio', { name: /^Spaces$/ });
-    await expect.element(spacesRadio).toBeDisabled();
+  it('resets only the Copy Selection context', async () => {
+    selectionSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '*', codeBlockStyle: 'indented' });
+    await startPage();
+    selectionSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '-', codeBlockStyle: 'fenced' });
 
-    const tabRadio = page.getByRole('radio', { name: /^Tab$/ });
-    await expect.element(tabRadio).toBeDisabled();
+    await page.getByTestId('reset-copy-selection').click();
+    await vi.waitFor(() => expect(resetSelectionSettingsMock).toHaveBeenCalledTimes(1));
+    await expect.element(page.getByRole('radio', { name: /Dashes/ })).toBeChecked();
+    await expect.element(page.getByRole('radio', { name: /Fenced code block/ })).toBeChecked();
+  });
+
+  it('flashes and shows the persisted values when a reset fails', async () => {
+    selectionSettingsMock.getAll.mockResolvedValue({ bulletListMarker: '*', codeBlockStyle: 'fenced' });
+    await startPage();
+    resetSelectionSettingsMock.mockRejectedValueOnce(new Error('fail'));
+
+    await page.getByTestId('reset-copy-selection').click();
+    await flush();
+
+    await expect.element(page.getByRole('radio', { name: /Asterisks/ })).toBeChecked();
+    await expect.element(page.getByTestId('flash-error')).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes #295. Final child of #290 — completes the context-owned formatting information architecture.

## What changed

**Navigation** — Formats (Copy Selection, Multiple Links, Single Link) and Others (Menu Commands, Advanced, Permissions, Help & Examples, About). The `General → Markdown Style` entry is gone; `options.html` — the page the browser opens for extension options — is now Copy Selection, so opening options lands there.

**Copy Selection** owns its bullet-list marker and code-block style, and nothing else.

**Multiple Links** gains its own bullet-list marker and tab-group indentation (with the existing tabGroups permission behaviour), served by a new `src/ui/multiple-links.ts` entry point. Task lists keep their fixed `- [ ]` marker.

**Single Link** stays an intentionally blank landing page with its custom-format child links and no reset.

The two bullet-list markers were already independent in storage (#292); this is what finally exposes them. A migrated profile starts with the legacy choice in both contexts and diverges only when the user changes one. Radio values are now the Markdown tokens themselves (`-`, `*`, `+`) rather than `dash`/`asterisk`/`plus`.

<img width="891" height="632" alt="截圖 2026-08-12 晚上11 31 45" src="https://github.com/user-attachments/assets/3265b15b-ef0b-4029-9923-2786ce2d49da" />
<img width="944" height="743" alt="截圖 2026-08-12 晚上11 31 50" src="https://github.com/user-attachments/assets/2346be6e-0a5d-4137-b1b2-29357eea9c14" />


## Per-page resets and legacy keys

Each page resets only what it owns; menu visibility, Advanced, permissions, and custom-format names/templates are untouched.

Resetting a context also retires the legacy keys that migrate into it — a legacy key that outlived a failed migration cleanup is still an unmigrated value, and would otherwise be migrated back over the defaults the user just asked for.

Because `styleOfUnorderedList ` is the migration source for *both* contexts, that retirement lives in `markdown-settings.ts` rather than in either context module (`resetSelectionSettings()` / `resetMultipleLinksSettings()`). A reset runs the idempotent migration first, which normally materializes both contexts and clears the legacy keys itself. When the shared key survives that with the other context still unmaterialized — a failed migration write, or a sibling value this version cannot read — it stays put, and the reset context records its defaults instead, which a later migration will not overwrite.

## Testing

- `npm run typecheck`, `npm run lint`
- `npm test` — 283 passed (unit 186 + browser 97), including new UI specs for both pages and unit coverage for reset isolation, legacy-key retirement, and the failed-migration-write case in both directions
- `npm run test:e2e:docker` — 173 passed, 0 flaky. New e2e covers the Copy Selection landing page, per-page persistence across reloads, reset isolation between the two contexts, and a migrated profile starting equal in both pages then diverging

## Notes for review

- The acceptance criterion "navigation and settings behavior work in both extension builds" is only exercised on Chromium: Playwright covers Chrome, and the Firefox suite is the pytest one that DEVELOPMENT.md records as currently broken. The Firefox build does get the new entry point.
- The two page controllers still share a lot of shape (load / save / failure re-read / reset / storage listener). Extracting a shared controller was tried and rejected: with only two consumers it breaks even on line count and amounts to a home-grown mini-framework. Better solved later by a real tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)